### PR TITLE
chore: add simple CI to run unit tests/coverage checks for pull requests and publish

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,24 @@
+name: Numaflow Java CI
+
+on:
+  push:
+    branches:
+      - "main"
+      - "release-*"
+      - "ci"
+  pull_request:
+    branches: [ main, ci ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven, run unit tests and the coverage check
+        run: mvn clean install

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,12 +2,9 @@ name: Numaflow Java CI
 
 on:
   push:
-    branches:
-      - "main"
-      - "release-*"
-      - "ci"
+    branches: [ main ]
   pull_request:
-    branches: [ main, ci ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.70</minimum>
+                                            <minimum>0.75</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,7 @@
                 <configuration>
                     <excludes>
                         <exclude>io/numaproj/numaflow/sink/v1/*</exclude>
+                        <exclude>io/numaproj/numaflow/function/v1/*</exclude>
                         <exclude>io/numaproj/numaflow/function/metadata/*</exclude>
                         <exclude>io/numaproj/numaflow/utils/*</exclude>
                     </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,6 @@
                 <configuration>
                     <excludes>
                         <exclude>io/numaproj/numaflow/sink/v1/*</exclude>
-                        <exclude>io/numaproj/numaflow/function/v1/*</exclude>
                         <exclude>io/numaproj/numaflow/function/metadata/*</exclude>
                         <exclude>io/numaproj/numaflow/utils/*</exclude>
                     </excludes>


### PR DESCRIPTION
Closes #14 

Also increase unit test coverage ratio limit from 70% to 75%. Thank you @yhl25 for creating high coverage commits, which raised our overall coverage by 5%. We might not require a 100% percentage but my goal is to make it at least 80%.

The change was tested on my branch https://github.com/KeranYang/numaflow-java/pull/3, where I mimicked a coverage failure and verified the CI workflow failed.