### PR TITLE
feat: Add ID and numDelivered fields to Datum in udf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
+            <version>1.18.26</version>
             <scope>compile</scope>
         </dependency>
 

--- a/src/main/java/io/numaproj/numaflow/function/Datum.java
+++ b/src/main/java/io/numaproj/numaflow/function/Datum.java
@@ -8,4 +8,6 @@ public interface Datum {
     public Instant getEventTime();
 
     public Instant getWatermark();
+
+    public DatumMetadata getDatumMetadata();
 }

--- a/src/main/java/io/numaproj/numaflow/function/DatumMetadata.java
+++ b/src/main/java/io/numaproj/numaflow/function/DatumMetadata.java
@@ -1,0 +1,7 @@
+package io.numaproj.numaflow.function;
+
+public interface DatumMetadata {
+    public String getId();
+
+    public long getNumDelivered();
+}

--- a/src/main/java/io/numaproj/numaflow/function/FunctionService.java
+++ b/src/main/java/io/numaproj/numaflow/function/FunctionService.java
@@ -68,6 +68,10 @@ public class FunctionService extends UserDefinedFunctionGrpc.UserDefinedFunction
         }
 
         // get Datum from request
+        HandlerDatumMetadata handlerDatumMetadata = new HandlerDatumMetadata(
+                request.getMetadata().getId(),
+                request.getMetadata().getNumDelivered()
+        );
         HandlerDatum handlerDatum = new HandlerDatum(
                 request.getValue().toByteArray(),
                 Instant.ofEpochSecond(
@@ -75,7 +79,8 @@ public class FunctionService extends UserDefinedFunctionGrpc.UserDefinedFunction
                         request.getWatermark().getWatermark().getNanos()),
                 Instant.ofEpochSecond(
                         request.getEventTime().getEventTime().getSeconds(),
-                        request.getEventTime().getEventTime().getNanos())
+                        request.getEventTime().getEventTime().getNanos()),
+                handlerDatumMetadata
         );
 
         // process Datum
@@ -101,6 +106,10 @@ public class FunctionService extends UserDefinedFunctionGrpc.UserDefinedFunction
         }
 
         // get Datum from request
+        HandlerDatumMetadata handlerDatumMetadata = new HandlerDatumMetadata(
+                request.getMetadata().getId(),
+                request.getMetadata().getNumDelivered()
+        );
         HandlerDatum handlerDatum = new HandlerDatum(
                 request.getValue().toByteArray(),
                 Instant.ofEpochSecond(
@@ -108,7 +117,8 @@ public class FunctionService extends UserDefinedFunctionGrpc.UserDefinedFunction
                         request.getWatermark().getWatermark().getNanos()),
                 Instant.ofEpochSecond(
                         request.getEventTime().getEventTime().getSeconds(),
-                        request.getEventTime().getEventTime().getNanos())
+                        request.getEventTime().getEventTime().getNanos()),
+                handlerDatumMetadata
         );
 
         // process Datum

--- a/src/main/java/io/numaproj/numaflow/function/HandlerDatum.java
+++ b/src/main/java/io/numaproj/numaflow/function/HandlerDatum.java
@@ -12,6 +12,8 @@ public class HandlerDatum implements Datum {
     private Instant watermark;
     private Instant eventTime;
 
+    private DatumMetadata datumMetadata;
+
     @Override
     public Instant getWatermark() {
         return this.watermark;
@@ -25,5 +27,10 @@ public class HandlerDatum implements Datum {
     @Override
     public Instant getEventTime() {
         return this.eventTime;
+    }
+
+    @Override
+    public DatumMetadata getDatumMetadata() {
+        return this.datumMetadata;
     }
 }

--- a/src/main/java/io/numaproj/numaflow/function/HandlerDatumMetadata.java
+++ b/src/main/java/io/numaproj/numaflow/function/HandlerDatumMetadata.java
@@ -1,0 +1,17 @@
+package io.numaproj.numaflow.function;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class HandlerDatumMetadata implements DatumMetadata {
+    private String id;
+    private long numDelivered;
+
+    public String getId() {
+        return this.id;
+    }
+
+    public long getNumDelivered() {
+        return this.numDelivered;
+    }
+}

--- a/src/main/java/io/numaproj/numaflow/function/reduce/ReduceSupervisorActor.java
+++ b/src/main/java/io/numaproj/numaflow/function/reduce/ReduceSupervisorActor.java
@@ -12,6 +12,7 @@ import io.grpc.stub.StreamObserver;
 import io.numaproj.numaflow.function.Function;
 import io.numaproj.numaflow.function.FunctionService;
 import io.numaproj.numaflow.function.HandlerDatum;
+import io.numaproj.numaflow.function.HandlerDatumMetadata;
 import io.numaproj.numaflow.function.metadata.Metadata;
 import io.numaproj.numaflow.function.v1.Udfunction;
 import lombok.extern.slf4j.Slf4j;
@@ -132,6 +133,10 @@ public class ReduceSupervisorActor extends AbstractActor {
     }
 
     private HandlerDatum constructHandlerDatum(Udfunction.DatumRequest datumRequest) {
+        HandlerDatumMetadata handlerDatumMetadata = new HandlerDatumMetadata(
+                datumRequest.getMetadata().getId(),
+                datumRequest.getMetadata().getNumDelivered()
+        );
         return new HandlerDatum(
                 datumRequest.getValue().toByteArray(),
                 Instant.ofEpochSecond(
@@ -139,7 +144,9 @@ public class ReduceSupervisorActor extends AbstractActor {
                         datumRequest.getWatermark().getWatermark().getNanos()),
                 Instant.ofEpochSecond(
                         datumRequest.getEventTime().getEventTime().getSeconds(),
-                        datumRequest.getEventTime().getEventTime().getNanos()));
+                        datumRequest.getEventTime().getEventTime().getNanos()),
+                handlerDatumMetadata
+        );
     }
 
     /*

--- a/src/main/proto/function/v1/udfunction.proto
+++ b/src/main/proto/function/v1/udfunction.proto
@@ -37,6 +37,14 @@ message Watermark {
 }
 
 /**
+ * Metadata of a datum element.
+ */
+message Metadata {
+  string id = 1;
+  uint64 num_delivered = 2;
+}
+
+/**
  * DatumRequest represents a datum request element.
  */
 message DatumRequest {
@@ -44,6 +52,7 @@ message DatumRequest {
   bytes value = 2;
   EventTime event_time = 3;
   Watermark watermark = 4;
+  Metadata metadata = 5;
 }
 
 /**


### PR DESCRIPTION
As part of https://github.com/numaproj/numaflow/issues/538, this PR adds ID and numDelivered fields to Datum in udf, so that users are exposed with these metadata information about the message.

It also upgrades `lombok` to `1.18.26` because of https://github.com/projectlombok/lombok/issues/3264.