### PR TITLE
fix: enable logging for simple sink

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -18,6 +18,11 @@
             <artifactId>numaflow-java</artifactId>
             <version>0.4.5</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.5</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.25</version>
+            <version>2.0.5</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Add dependency of slf4j-simple to examples such that the simple sink can actually log the message. This is to fix e2e tests using java udsink.

The reason why it's not working is because the **main** pom.xml [specifies the dependency](https://github.com/numaproj/numaflow-java/blob/main/pom.xml#L112) to to only use slf4j-simple under `test` folder. By explicitly declaring it at **examples** pom.xml, we override the main pom.xml specification.