### PR TITLE
feat: grpc error handling for Map/MapT/MapStream/Reduce/Sink

### DIFF
--- a/src/main/java/io/numaproj/numaflow/function/FunctionService.java
+++ b/src/main/java/io/numaproj/numaflow/function/FunctionService.java
@@ -296,14 +296,13 @@ class FunctionService extends UserDefinedFunctionGrpc.UserDefinedFunctionImplBas
         return datumListBuilder.build();
     }
 
-    // log the exception and exit if there are any uncaught exceptions.
+    // wrap the exception and let it be handled in the central error handling logic.
     private void handleFailure(CompletableFuture<Void> failureFuture) {
         new Thread(() -> {
             try {
                 failureFuture.get();
             } catch (Exception e) {
-                e.printStackTrace();
-                System.exit(1);
+                throw new RuntimeException("error in reduce fn", e);
             }
         }).start();
     }

--- a/src/main/java/io/numaproj/numaflow/function/ReduceShutdownActor.java
+++ b/src/main/java/io/numaproj/numaflow/function/ReduceShutdownActor.java
@@ -4,8 +4,6 @@ import akka.actor.AbstractActor;
 import akka.actor.AllDeadLetters;
 import akka.actor.Props;
 import akka.japi.pf.ReceiveBuilder;
-import io.grpc.stub.StreamObserver;
-import io.numaproj.numaflow.function.v1.Udfunction;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -20,13 +18,11 @@ import java.util.concurrent.CompletableFuture;
 @Slf4j
 @AllArgsConstructor
 class ReduceShutdownActor extends AbstractActor {
-    private StreamObserver<Udfunction.DatumResponseList> responseObserver;
     private final CompletableFuture<Void> failureFuture;
 
     public static Props props(
-            StreamObserver<Udfunction.DatumResponseList> responseObserver,
             CompletableFuture<Void> failureFuture) {
-        return Props.create(ReduceShutdownActor.class, responseObserver, failureFuture);
+        return Props.create(ReduceShutdownActor.class, failureFuture);
     }
 
     @Override
@@ -51,7 +47,6 @@ class ReduceShutdownActor extends AbstractActor {
     private void shutdown(Throwable throwable) {
         log.debug("got a shut down exception");
         failureFuture.completeExceptionally(throwable);
-        responseObserver.onError(throwable);
     }
 
     // if there are no exceptions, complete the future without exception.

--- a/src/main/java/io/numaproj/numaflow/sink/SinkServer.java
+++ b/src/main/java/io/numaproj/numaflow/sink/SinkServer.java
@@ -1,14 +1,8 @@
 package io.numaproj.numaflow.sink;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.grpc.ForwardingServerCallListener;
-import io.grpc.Metadata;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
-import io.grpc.ServerCall;
-import io.grpc.ServerCallHandler;
-import io.grpc.ServerInterceptor;
-import io.grpc.Status;
 import io.grpc.netty.NettyServerBuilder;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.epoll.EpollServerDomainSocketChannel;
@@ -101,33 +95,8 @@ public class SinkServer {
         serverInfoAccessor.write(serverInfo, infoFilePath);
 
         // build server
-        ServerInterceptor interceptor = new ServerInterceptor() {
-            @Override
-            public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
-                    ServerCall<ReqT, RespT> call,
-                    Metadata headers,
-                    ServerCallHandler<ReqT, RespT> next) {
-                return new ForwardingServerCallListener.SimpleForwardingServerCallListener<>(next.startCall(call, headers)) {
-                    @Override
-                    public void onHalfClose() {
-                        try {
-                            super.onHalfClose();
-                        } catch (RuntimeException ex) {
-                            handleException(ex, call, headers);
-                            throw ex;
-                        }
-                    }
-                    private void handleException(RuntimeException exception, ServerCall<ReqT, RespT> serverCall, Metadata headers) {
-                        // Currently, we only have application level exceptions.
-                        // Translate it to UNKNOWN status.
-                        serverCall.close(Status.UNKNOWN, headers);
-                    }
-                };
-            }
-        };
         server = serverBuilder
                 .addService(this.sinkService)
-                .intercept(interceptor)
                 .build();
 
         // start server

--- a/src/main/java/io/numaproj/numaflow/sink/SinkServer.java
+++ b/src/main/java/io/numaproj/numaflow/sink/SinkServer.java
@@ -1,8 +1,14 @@
 package io.numaproj.numaflow.sink;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.grpc.ForwardingServerCallListener;
+import io.grpc.Metadata;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
 import io.grpc.netty.NettyServerBuilder;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.epoll.EpollServerDomainSocketChannel;
@@ -95,8 +101,33 @@ public class SinkServer {
         serverInfoAccessor.write(serverInfo, infoFilePath);
 
         // build server
+        ServerInterceptor interceptor = new ServerInterceptor() {
+            @Override
+            public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+                    ServerCall<ReqT, RespT> call,
+                    Metadata headers,
+                    ServerCallHandler<ReqT, RespT> next) {
+                return new ForwardingServerCallListener.SimpleForwardingServerCallListener<>(next.startCall(call, headers)) {
+                    @Override
+                    public void onHalfClose() {
+                        try {
+                            super.onHalfClose();
+                        } catch (RuntimeException ex) {
+                            handleException(ex, call, headers);
+                            throw ex;
+                        }
+                    }
+                    private void handleException(RuntimeException exception, ServerCall<ReqT, RespT> serverCall, Metadata headers) {
+                        // Currently, we only have application level exceptions.
+                        // Translate it to UNKNOWN status.
+                        serverCall.close(Status.UNKNOWN, headers);
+                    }
+                };
+            }
+        };
         server = serverBuilder
                 .addService(this.sinkService)
+                .intercept(interceptor)
                 .build();
 
         // start server

--- a/src/main/java/io/numaproj/numaflow/sink/SinkService.java
+++ b/src/main/java/io/numaproj/numaflow/sink/SinkService.java
@@ -88,16 +88,13 @@ class SinkService extends UserDefinedSinkGrpc.UserDefinedSinkImplBase {
         responseObserver.onCompleted();
     }
 
-
-
-    // log the exception and exit if there are any uncaught exceptions.
+    // wrap the exception and let it be handled in the central error handling logic.
     private void handleFailure(CompletableFuture<Void> failureFuture) {
         new Thread(() -> {
             try {
                 failureFuture.get();
             } catch (Exception e) {
-                e.printStackTrace();
-                System.exit(1);
+                throw new RuntimeException("error in sinker fn", e);
             }
         }).start();
     }

--- a/src/main/java/io/numaproj/numaflow/sink/SinkService.java
+++ b/src/main/java/io/numaproj/numaflow/sink/SinkService.java
@@ -4,6 +4,7 @@ import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.AllDeadLetters;
 import com.google.protobuf.Empty;
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import io.numaproj.numaflow.sink.handler.SinkHandler;
 import io.numaproj.numaflow.sink.v1.Udsink;
@@ -43,12 +44,12 @@ class SinkService extends UserDefinedSinkGrpc.UserDefinedSinkImplBase {
 
         // create a shutdown actor that listens to exceptions.
         ActorRef shutdownActorRef = sinkActorSystem.
-                actorOf(SinkShutdownActor.props(responseObserver, failureFuture));
+                actorOf(SinkShutdownActor.props(failureFuture));
 
         // subscribe for dead letters
         sinkActorSystem.getEventStream().subscribe(shutdownActorRef, AllDeadLetters.class);
 
-        handleFailure(failureFuture);
+        handleFailure(failureFuture, responseObserver);
 
         /*
             supervisor actor to create and manage the sink actor which invokes the handlers.
@@ -88,13 +89,15 @@ class SinkService extends UserDefinedSinkGrpc.UserDefinedSinkImplBase {
         responseObserver.onCompleted();
     }
 
-    // wrap the exception and let it be handled in the central error handling logic.
-    private void handleFailure(CompletableFuture<Void> failureFuture) {
+    // handle the exception with corresponding response status code.
+    private void handleFailure(CompletableFuture<Void> failureFuture, StreamObserver<Udsink.ResponseList> responseObserver) {
         new Thread(() -> {
             try {
                 failureFuture.get();
             } catch (Exception e) {
-                throw new RuntimeException("error in sinker fn", e);
+                e.printStackTrace();
+                var status = Status.UNKNOWN.withDescription(e.getMessage()).withCause(e);
+                responseObserver.onError(status.asException());
             }
         }).start();
     }

--- a/src/main/java/io/numaproj/numaflow/sink/SinkShutdownActor.java
+++ b/src/main/java/io/numaproj/numaflow/sink/SinkShutdownActor.java
@@ -4,8 +4,6 @@ import akka.actor.AbstractActor;
 import akka.actor.AllDeadLetters;
 import akka.actor.Props;
 import akka.japi.pf.ReceiveBuilder;
-import io.grpc.stub.StreamObserver;
-import io.numaproj.numaflow.sink.v1.Udsink;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -20,13 +18,10 @@ import java.util.concurrent.CompletableFuture;
 @Slf4j
 @AllArgsConstructor
 class SinkShutdownActor extends AbstractActor {
-    private StreamObserver<Udsink.ResponseList> responseObserver;
     private final CompletableFuture<Void> failureFuture;
 
-    public static Props props(
-            StreamObserver<Udsink.ResponseList> responseObserver,
-            CompletableFuture<Void> failureFuture) {
-        return Props.create(SinkShutdownActor.class, responseObserver, failureFuture);
+    public static Props props(CompletableFuture<Void> failureFuture) {
+        return Props.create(SinkShutdownActor.class, failureFuture);
     }
 
     @Override
@@ -51,7 +46,6 @@ class SinkShutdownActor extends AbstractActor {
     private void shutdown(Throwable throwable) {
         log.debug("got a shut down exception");
         failureFuture.completeExceptionally(throwable);
-        responseObserver.onError(throwable);
     }
 
     // if there are no exceptions, complete the future without exception.

--- a/src/test/java/io/numaproj/numaflow/function/FunctionServerTestErr.java
+++ b/src/test/java/io/numaproj/numaflow/function/FunctionServerTestErr.java
@@ -1,0 +1,202 @@
+package io.numaproj.numaflow.function;
+
+import com.google.protobuf.ByteString;
+import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.MetadataUtils;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcCleanupRule;
+import io.numaproj.numaflow.function.handlers.MapHandler;
+import io.numaproj.numaflow.function.handlers.MapStreamHandler;
+import io.numaproj.numaflow.function.handlers.MapTHandler;
+import io.numaproj.numaflow.function.interfaces.Datum;
+import io.numaproj.numaflow.function.types.MessageList;
+import io.numaproj.numaflow.function.types.MessageTList;
+import io.numaproj.numaflow.function.v1.Udfunction;
+import io.numaproj.numaflow.function.v1.Udfunction.EventTime;
+import io.numaproj.numaflow.function.v1.UserDefinedFunctionGrpc;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.time.Instant;
+import java.util.List;
+
+import static io.numaproj.numaflow.function.FunctionConstants.WIN_END_KEY;
+import static io.numaproj.numaflow.function.FunctionConstants.WIN_START_KEY;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(JUnit4.class)
+public class FunctionServerTestErr {
+    @Rule
+    public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+    private FunctionServer server;
+    private ManagedChannel inProcessChannel;
+
+    @Before
+    public void setUp() throws Exception {
+        String serverName = InProcessServerBuilder.generateName();
+
+        FunctionGRPCConfig grpcServerConfig = new FunctionGRPCConfig(FunctionConstants.DEFAULT_MESSAGE_SIZE);
+        grpcServerConfig.setInfoFilePath("/tmp/numaflow-test-server-info");
+        server = new FunctionServer(
+                InProcessServerBuilder.forName(serverName).directExecutor(),
+                grpcServerConfig);
+
+        server.registerMapHandler(new TestMapFnErr())
+                .registerMapStreamHandler(new TestMapStreamFnErr())
+                .registerMapTHandler(new TestMapTFnErr())
+                .registerReducerFactory(new ReduceTestFactoryErr())
+                .start();
+
+        inProcessChannel = grpcCleanup.register(InProcessChannelBuilder
+                .forName(serverName)
+                .directExecutor()
+                .build());
+    }
+
+    @After
+    public void tearDown() {
+        server.stop();
+    }
+
+    @Test
+    public void mapperErr() {
+        ByteString inValue = ByteString.copyFromUtf8("invalue");
+        Udfunction.DatumRequest inDatum = Udfunction.DatumRequest
+                .newBuilder()
+                .addAllKeys(List.of("test-map-key"))
+                .setValue(inValue)
+                .build();
+
+        var stub = UserDefinedFunctionGrpc.newBlockingStub(inProcessChannel);
+        try {
+            stub.mapFn(inDatum);
+        } catch (Exception e) {
+            assertEquals(Status.UNKNOWN.getCode().toString(), e.getMessage());
+        }
+    }
+
+    @Test
+    public void mapperStream() {
+        ByteString inValue = ByteString.copyFromUtf8("invalue");
+        Udfunction.DatumRequest inDatum = Udfunction.DatumRequest
+                .newBuilder()
+                .addAllKeys(List.of("test-map-key"))
+                .setValue(inValue)
+                .build();
+
+        var stub = UserDefinedFunctionGrpc.newBlockingStub(inProcessChannel);
+        try {
+            stub.mapStreamFn(inDatum);
+        } catch (Exception e) {
+            assertEquals(Status.UNKNOWN.getCode().toString(), e.getMessage());
+        }
+    }
+
+    @Test
+    public void mapperT() {
+        ByteString inValue = ByteString.copyFromUtf8("invalue");
+        Udfunction.DatumRequest inDatum = Udfunction.DatumRequest
+                .newBuilder()
+                .addKeys("test-map-key")
+                .setValue(inValue)
+                .build();
+
+        var stub = UserDefinedFunctionGrpc.newBlockingStub(inProcessChannel);
+        try {
+            stub.mapTFn(inDatum);
+        } catch (Exception e) {
+            assertEquals(Status.UNKNOWN.getCode().toString(), e.getMessage());
+        }
+    }
+
+    @Test
+    public void reducerWithOneKey() {
+        String reduceKey = "reduce-key";
+
+        Metadata metadata = new Metadata();
+        metadata.put(Metadata.Key.of(WIN_START_KEY, Metadata.ASCII_STRING_MARSHALLER), "60000");
+        metadata.put(Metadata.Key.of(WIN_END_KEY, Metadata.ASCII_STRING_MARSHALLER), "120000");
+
+        //create an output stream observer
+        ReduceOutputStreamObserver outputStreamObserver = new ReduceOutputStreamObserver();
+
+        try {
+            StreamObserver<Udfunction.DatumRequest> inputStreamObserver = UserDefinedFunctionGrpc
+                    .newStub(inProcessChannel)
+                    .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata))
+                    .reduceFn(outputStreamObserver);
+
+            for (int i = 1; i <= 10; i++) {
+                Udfunction.DatumRequest inputDatum = Udfunction.DatumRequest.newBuilder()
+                        .setValue(ByteString.copyFromUtf8(String.valueOf(i)))
+                        .addKeys(reduceKey)
+                        .build();
+                inputStreamObserver.onNext(inputDatum);
+            }
+
+            inputStreamObserver.onCompleted();
+
+        } catch (Exception e) {
+            assertEquals(Status.UNKNOWN.getCode().toString(), e.getMessage());
+        }
+    }
+
+    @Test
+    public void reducerWithMultipleKey() {
+        String reduceKey = "reduce-key";
+
+        Metadata metadata = new Metadata();
+        metadata.put(Metadata.Key.of(WIN_START_KEY, Metadata.ASCII_STRING_MARSHALLER), "60000");
+        metadata.put(Metadata.Key.of(WIN_END_KEY, Metadata.ASCII_STRING_MARSHALLER), "120000");
+
+        //create an output stream observer
+        ReduceOutputStreamObserver outputStreamObserver = new ReduceOutputStreamObserver();
+
+        try {
+            StreamObserver<Udfunction.DatumRequest> inputStreamObserver = UserDefinedFunctionGrpc
+                    .newStub(inProcessChannel)
+                    .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata))
+                    .reduceFn(outputStreamObserver);
+            for (int i = 1; i <= 10; i++) {
+                Udfunction.DatumRequest inputDatum = Udfunction.DatumRequest.newBuilder()
+                        .setValue(ByteString.copyFromUtf8(String.valueOf(i)))
+                        .addKeys(reduceKey)
+                        .build();
+                inputStreamObserver.onNext(inputDatum);
+            }
+
+            inputStreamObserver.onCompleted();
+        } catch (Exception e) {
+            assertEquals(Status.UNKNOWN.getCode().toString(), e.getMessage());
+        }
+    }
+
+    private static class TestMapFnErr extends MapHandler {
+        @Override
+        public MessageList processMessage(String[] keys, Datum datum) {
+            throw new RuntimeException("unknown exception");
+        }
+    }
+
+    private static class TestMapStreamFnErr extends MapStreamHandler {
+        @Override
+        public void processMessage(String[] keys, Datum datum, StreamObserver<Udfunction.DatumResponse> streamObserver) {
+            throw new RuntimeException("unknown exception");
+        }
+    }
+
+    private static class TestMapTFnErr extends MapTHandler {
+        @Override
+        public MessageTList processMessage(String[] keys, Datum datum) {
+            throw new RuntimeException("unknown exception");
+        }
+    }
+}

--- a/src/test/java/io/numaproj/numaflow/function/ReduceSupervisorActorTest.java
+++ b/src/test/java/io/numaproj/numaflow/function/ReduceSupervisorActorTest.java
@@ -34,9 +34,7 @@ public class ReduceSupervisorActorTest {
 
         ActorRef shutdownActor = actorSystem
                 .actorOf(ReduceShutdownActor
-                        .props(
-                                new ReduceOutputStreamObserver(),
-                                completableFuture));
+                        .props(completableFuture));
 
         Metadata md = new MetadataImpl(
                 new IntervalWindowImpl(Instant.now(), Instant.now()));
@@ -71,9 +69,7 @@ public class ReduceSupervisorActorTest {
 
         ActorRef shutdownActor = actorSystem
                 .actorOf(ReduceShutdownActor
-                        .props(
-                                new ReduceOutputStreamObserver(),
-                                completableFuture));
+                        .props(completableFuture));
 
         Metadata md = new MetadataImpl(
                 new IntervalWindowImpl(Instant.now(), Instant.now()));

--- a/src/test/java/io/numaproj/numaflow/function/ReduceTestFactoryErr.java
+++ b/src/test/java/io/numaproj/numaflow/function/ReduceTestFactoryErr.java
@@ -1,0 +1,38 @@
+package io.numaproj.numaflow.function;
+
+import io.numaproj.numaflow.function.handlers.ReduceHandler;
+import io.numaproj.numaflow.function.handlers.ReducerFactory;
+import io.numaproj.numaflow.function.interfaces.Datum;
+import io.numaproj.numaflow.function.interfaces.Metadata;
+import io.numaproj.numaflow.function.types.Message;
+import io.numaproj.numaflow.function.types.MessageList;
+
+import java.util.Arrays;
+
+public class ReduceTestFactoryErr extends ReducerFactory<ReduceTestFactoryErr.ReduceTestFn> {
+    @Override
+    public ReduceTestFn createReducer() {
+        return new ReduceTestFn();
+    }
+
+    public static class ReduceTestFn extends ReduceHandler {
+        private int sum = 0;
+
+        @Override
+        public void addMessage(String[] keys, Datum datum, Metadata md) {
+            throw new RuntimeException("unknown exception");
+        }
+
+        @Override
+        public MessageList getOutput(String[] keys, Metadata md) {
+            String[] updatedKeys = Arrays
+                    .stream(keys)
+                    .map(c -> c + "-processed")
+                    .toArray(String[]::new);
+            return MessageList
+                    .newBuilder()
+                    .addMessage(new Message(String.valueOf(sum).getBytes(), updatedKeys))
+                    .build();
+        }
+    }
+}

--- a/src/test/java/io/numaproj/numaflow/function/ShutDownActorTest.java
+++ b/src/test/java/io/numaproj/numaflow/function/ShutDownActorTest.java
@@ -36,9 +36,7 @@ public class ShutDownActorTest {
 
         ActorRef shutdownActor = actorSystem
                 .actorOf(ReduceShutdownActor
-                        .props(
-                                new ReduceOutputStreamObserver(),
-                                completableFuture));
+                        .props(completableFuture));
 
         Metadata md = new MetadataImpl(
                 new IntervalWindowImpl(Instant.now(), Instant.now()));
@@ -72,9 +70,7 @@ public class ShutDownActorTest {
 
         ActorRef shutdownActor = actorSystem
                 .actorOf(ReduceShutdownActor
-                        .props(
-                                new ReduceOutputStreamObserver(),
-                                completableFuture));
+                        .props(completableFuture));
 
         actorSystem.eventStream().subscribe(shutdownActor, AllDeadLetters.class);
 

--- a/src/test/java/io/numaproj/numaflow/sink/SinkOutputStreamObserver.java
+++ b/src/test/java/io/numaproj/numaflow/sink/SinkOutputStreamObserver.java
@@ -9,6 +9,7 @@ public class SinkOutputStreamObserver implements StreamObserver<Udsink.ResponseL
     private Udsink.ResponseList resultDatum;
     public AtomicReference<Boolean> completed = new AtomicReference<>(false);
 
+    public Throwable t;
 
     public Udsink.ResponseList getResultDatum() {
         return resultDatum;
@@ -21,7 +22,7 @@ public class SinkOutputStreamObserver implements StreamObserver<Udsink.ResponseL
 
     @Override
     public void onError(Throwable throwable) {
-        throwable.printStackTrace();
+        t = throwable;
     }
 
     @Override

--- a/src/test/java/io/numaproj/numaflow/sink/SinkServerTestErr.java
+++ b/src/test/java/io/numaproj/numaflow/sink/SinkServerTestErr.java
@@ -1,0 +1,99 @@
+package io.numaproj.numaflow.sink;
+
+import com.google.protobuf.ByteString;
+import io.grpc.ManagedChannel;
+import io.grpc.Status;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcCleanupRule;
+import io.numaproj.numaflow.sink.handler.SinkHandler;
+import io.numaproj.numaflow.sink.interfaces.Datum;
+import io.numaproj.numaflow.sink.types.Response;
+import io.numaproj.numaflow.sink.types.ResponseList;
+import io.numaproj.numaflow.sink.v1.Udsink;
+import io.numaproj.numaflow.sink.v1.UserDefinedSinkGrpc;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@Slf4j
+@RunWith(JUnit4.class)
+public class SinkServerTestErr {
+    private final static String processedIdSuffix = "-id-processed";
+    @Rule
+    public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+    private SinkServer server;
+    private ManagedChannel inProcessChannel;
+
+    @Before
+    public void setUp() throws Exception {
+        String serverName = InProcessServerBuilder.generateName();
+        SinkGRPCConfig grpcServerConfig = new SinkGRPCConfig(SinkConstants.DEFAULT_MESSAGE_SIZE);
+        grpcServerConfig.setInfoFilePath("/tmp/numaflow-test-server-info");
+        server = new SinkServer(
+                InProcessServerBuilder.forName(serverName).directExecutor(),
+                grpcServerConfig);
+        server.registerSinker(new TestSinkFnErr()).start();
+        inProcessChannel = grpcCleanup.register(InProcessChannelBuilder
+                .forName(serverName)
+                .directExecutor()
+                .build());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+    }
+
+    @Test
+    public void sinkerSuccess() throws InterruptedException {
+        //create an output stream observer
+        SinkOutputStreamObserver outputStreamObserver = new SinkOutputStreamObserver();
+
+        try {
+            StreamObserver<Udsink.DatumRequest> inputStreamObserver = UserDefinedSinkGrpc
+                    .newStub(inProcessChannel)
+                    .sinkFn(outputStreamObserver);
+            String actualId = "sink_test_id";
+            String expectedId = actualId + processedIdSuffix;
+
+            for (int i = 1; i <= 100; i++) {
+                String[] keys;
+                if (i < 100) {
+                    keys = new String[]{"valid-key"};
+                } else {
+                    keys = new String[]{"invalid-key"};
+                }
+                Udsink.DatumRequest inputDatum = Udsink.DatumRequest.newBuilder()
+                        .setValue(ByteString.copyFromUtf8(String.valueOf(i)))
+                        .setId(actualId)
+                        .addAllKeys(List.of(keys))
+                        .build();
+                inputStreamObserver.onNext(inputDatum);
+            }
+
+            inputStreamObserver.onCompleted();
+        } catch (Exception e) {
+            assertEquals(Status.UNKNOWN.getCode().toString(), e.getMessage());
+        }
+    }
+
+    @Slf4j
+    private static class TestSinkFnErr extends SinkHandler {
+
+        @Override
+        public Response processMessage(Datum datum) {
+            throw new RuntimeException("unknown exception");
+        }
+    }
+}


### PR DESCRIPTION
Closes [#769](https://github.com/numaproj/numaflow/issues/769)

This PR introduces a global GRPC interceptor for error handling (instead of handling cases one by one, which can be clumsy and easy to miss cases that needs to be handled). Although now exception can only happen at user custom code (application errors) which are translated to `UNKNOWN` grpc error code to be retried. The error handling logic can be extended easily to handle more type of exception if needed in future.

Also note that exception in reduce and sink now will no longer cause panic and exit but return with `UNKNOWN` grpc error to match the behavior in python and go sdk side.