### PR TITLE
refactor: simplify sinker api

### DIFF
--- a/examples/src/main/java/io/numaproj/numaflow/examples/sink/simple/SimpleSink.java
+++ b/examples/src/main/java/io/numaproj/numaflow/examples/sink/simple/SimpleSink.java
@@ -1,6 +1,5 @@
 package io.numaproj.numaflow.examples.sink.simple;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.numaproj.numaflow.sinker.Datum;
 import io.numaproj.numaflow.sinker.Response;
 import io.numaproj.numaflow.sinker.ResponseList;
@@ -15,8 +14,8 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class SimpleSink extends Sinker {
-    private final ObjectMapper mapper = new ObjectMapper();
     private final ResponseList.ResponseListBuilder responseListBuilder = ResponseList.newBuilder();
+
     public static void main(String[] args) throws Exception {
         new Server(new SimpleSink()).start();
     }
@@ -28,7 +27,9 @@ public class SimpleSink extends Sinker {
             log.info("Received message: {}", msg);
             responseListBuilder.addResponse(Response.responseOK(datum.getId()));
         } catch (Exception e) {
-            responseListBuilder.addResponse(Response.responseFailure(datum.getId(), e.getMessage()));
+            responseListBuilder.addResponse(Response.responseFailure(
+                    datum.getId(),
+                    e.getMessage()));
         }
     }
 

--- a/examples/src/main/java/io/numaproj/numaflow/examples/sink/simple/SimpleSink.java
+++ b/examples/src/main/java/io/numaproj/numaflow/examples/sink/simple/SimpleSink.java
@@ -2,7 +2,6 @@ package io.numaproj.numaflow.examples.sink.simple;
 
 import io.numaproj.numaflow.sinker.Datum;
 import io.numaproj.numaflow.sinker.Response;
-import io.numaproj.numaflow.sinker.ResponseList;
 import io.numaproj.numaflow.sinker.Server;
 import io.numaproj.numaflow.sinker.Sinker;
 import lombok.extern.slf4j.Slf4j;
@@ -14,33 +13,21 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class SimpleSink extends Sinker {
-    private final ResponseList.ResponseListBuilder responseListBuilder = ResponseList.newBuilder();
 
     public static void main(String[] args) throws Exception {
         new Server(new SimpleSink()).start();
     }
 
     @Override
-    public void processMessage(Datum datum) {
+    public Response processMessage(Datum datum) {
         try {
             String msg = new String(datum.getValue());
             log.info("Received message: {}", msg);
-            responseListBuilder.addResponse(Response.responseOK(datum.getId()));
+            return Response.responseOK(datum.getId());
         } catch (Exception e) {
-            responseListBuilder.addResponse(Response.responseFailure(
+            return Response.responseFailure(
                     datum.getId(),
-                    e.getMessage()));
-        }
-    }
-
-    @Override
-    public ResponseList getResponse() {
-        // Reset the builder after building the response to avoid keeping old responses in memory
-        // this is required as the same sinker instance is used for multiple requests
-        try {
-            return responseListBuilder.build();
-        } finally {
-            responseListBuilder.clearResponses();
+                    e.getMessage());
         }
     }
 }

--- a/src/main/java/io/numaproj/numaflow/sinker/Datum.java
+++ b/src/main/java/io/numaproj/numaflow/sinker/Datum.java
@@ -8,29 +8,36 @@ import java.time.Instant;
 public interface Datum {
     /**
      * method to get the payload keys
+     *
      * @return returns the datum keys.
      */
-    public abstract String[] getKeys();
+    String[] getKeys();
+
     /**
      * method to get the payload value
+     *
      * @return returns the payload value in byte array
      */
-    public abstract byte[] getValue();
+    byte[] getValue();
 
     /**
      * method to get the event time of the payload
+     *
      * @return returns the event time of the payload
      */
-    public abstract Instant getEventTime();
+    Instant getEventTime();
+
     /**
      * method to get the watermark information
+     *
      * @return returns the watermark
      */
-    public abstract Instant getWatermark();
+    Instant getWatermark();
 
     /**
      * method to get the ID for the Payload
+     *
      * @return returns the ID
      */
-    public abstract String getId();
+    String getId();
 }

--- a/src/main/java/io/numaproj/numaflow/sinker/ResponseList.java
+++ b/src/main/java/io/numaproj/numaflow/sinker/ResponseList.java
@@ -4,9 +4,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Singular;
 
-import java.util.ArrayList;
-import java.util.Collection;
-
 /**
  * ResponseList is used to return the list of responses from udsink
  */
@@ -14,18 +11,6 @@ import java.util.Collection;
 @Getter
 @Builder(builderMethodName = "newBuilder")
 public class ResponseList {
-
     @Singular("addResponse")
     private Iterable<Response> responses;
-
-    public static class ResponseListBuilder {
-        public ResponseListBuilder addResponses(Iterable<Response> responses) {
-            if (this.responses == null) {
-                this.responses = new ArrayList<>();
-                return this;
-            }
-            this.responses.addAll((Collection<? extends Response>) responses);
-            return this;
-        }
-    }
 }

--- a/src/main/java/io/numaproj/numaflow/sinker/ResponseList.java
+++ b/src/main/java/io/numaproj/numaflow/sinker/ResponseList.java
@@ -13,4 +13,9 @@ import lombok.Singular;
 public class ResponseList {
     @Singular("addResponse")
     private Iterable<Response> responses;
+
+    // Javadoc "cannot find symbol" when using lombok builder.
+    // We explicitly declare the builder here to make Javadoc happy.
+    public static class ResponseListBuilder {
+    }
 }

--- a/src/main/java/io/numaproj/numaflow/sinker/Server.java
+++ b/src/main/java/io/numaproj/numaflow/sinker/Server.java
@@ -23,6 +23,7 @@ public class Server {
 
     /**
      * constructor to create sink gRPC server.
+     *
      * @param sinker sink to process the message
      */
     public Server(Sinker sinker) {
@@ -42,10 +43,14 @@ public class Server {
 
     /**
      * Start serving requests.
+     *
      * @throws Exception if server fails to start
      */
     public void start() throws Exception {
-        GrpcServerUtils.writeServerInfo(serverInfoAccessor, grpcConfig.getSocketPath(), grpcConfig.getInfoFilePath());
+        GrpcServerUtils.writeServerInfo(
+                serverInfoAccessor,
+                grpcConfig.getSocketPath(),
+                grpcConfig.getInfoFilePath());
 
         if (this.server == null) {
             // create server builder
@@ -60,9 +65,7 @@ public class Server {
 
         // start server
         server.start();
-
-        log.info(
-                "Server started, listening on socket path: " + grpcConfig.getSocketPath());
+        log.info("Server started, listening on socket path: " + grpcConfig.getSocketPath());
 
         // register shutdown hook
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
@@ -80,6 +83,7 @@ public class Server {
     /**
      * Stop serving requests and shutdown resources. Await termination on the main thread since the
      * grpc library uses daemon threads.
+     *
      * @throws InterruptedException if shutdown is interrupted
      */
     public void stop() throws InterruptedException {
@@ -90,6 +94,7 @@ public class Server {
 
     /**
      * Set server builder for testing.
+     *
      * @param serverBuilder
      */
     @VisibleForTesting

--- a/src/main/java/io/numaproj/numaflow/sinker/Service.java
+++ b/src/main/java/io/numaproj/numaflow/sinker/Service.java
@@ -56,7 +56,7 @@ class Service extends SinkGrpc.SinkImplBase {
                         responseObserver
                 ));
 
-        return new StreamObserver<SinkOuterClass.SinkRequest>() {
+        return new StreamObserver<>() {
             @Override
             public void onNext(SinkOuterClass.SinkRequest d) {
                 supervisorActor.tell(d, ActorRef.noSender());
@@ -79,13 +79,17 @@ class Service extends SinkGrpc.SinkImplBase {
      * IsReady is the heartbeat endpoint for gRPC.
      */
     @Override
-    public void isReady(Empty request, StreamObserver<SinkOuterClass.ReadyResponse> responseObserver) {
+    public void isReady(
+            Empty request,
+            StreamObserver<SinkOuterClass.ReadyResponse> responseObserver) {
         responseObserver.onNext(SinkOuterClass.ReadyResponse.newBuilder().setReady(true).build());
         responseObserver.onCompleted();
     }
 
     // handle the exception with corresponding response status code.
-    private void handleFailure(CompletableFuture<Void> failureFuture, StreamObserver<SinkOuterClass.SinkResponse> responseObserver) {
+    private void handleFailure(
+            CompletableFuture<Void> failureFuture,
+            StreamObserver<SinkOuterClass.SinkResponse> responseObserver) {
         new Thread(() -> {
             try {
                 failureFuture.get();

--- a/src/main/java/io/numaproj/numaflow/sinker/SinkActor.java
+++ b/src/main/java/io/numaproj/numaflow/sinker/SinkActor.java
@@ -9,7 +9,6 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * Sink actor invokes the user defined sink and returns the response back on EOF.
  */
-
 @Slf4j
 class SinkActor extends AbstractActor {
 

--- a/src/main/java/io/numaproj/numaflow/sinker/SinkActor.java
+++ b/src/main/java/io/numaproj/numaflow/sinker/SinkActor.java
@@ -8,6 +8,10 @@ import lombok.extern.slf4j.Slf4j;
 
 /**
  * Sink actor invokes the user defined sink and returns the response back on EOF.
+ * <p>
+ * When receiving a HandlerDatum, the sinker processes the message and the actor adds the response to a response list.
+ * When receiving a string indicating EOF,
+ * the sink actor sends the responses to supervisor actor and clean up the response list to prepare for the next batch.
  */
 @Slf4j
 class SinkActor extends AbstractActor {

--- a/src/main/java/io/numaproj/numaflow/sinker/SinkSupervisorActor.java
+++ b/src/main/java/io/numaproj/numaflow/sinker/SinkSupervisorActor.java
@@ -110,7 +110,6 @@ class SinkSupervisorActor extends AbstractActor {
                 akka.actor.ActorContext context,
                 ActorRef child,
                 Iterable<ActorRef> children) {
-
         }
 
         @Override
@@ -125,9 +124,8 @@ class SinkSupervisorActor extends AbstractActor {
             Preconditions.checkArgument(
                     !restart,
                     "on failures, we will never restart our actors, we escalate");
-            /*
-                   tell the shutdown actor about the exception.
-             */
+
+            // tell the shutdown actor about the exception.
             log.debug("process failure of supervisor strategy executed - {}", getSelf().toString());
             shutdownActor.tell(cause, context.parent());
             getContext().getSystem().stop(getSelf());
@@ -149,13 +147,14 @@ class SinkSupervisorActor extends AbstractActor {
 
     public SinkOuterClass.SinkResponse buildResponseList(ResponseList responses) {
         var responseBuilder = SinkOuterClass.SinkResponse.newBuilder();
-        responses.getResponses().forEach(response -> {
-            responseBuilder.addResults(SinkOuterClass.SinkResponse.Result.newBuilder()
-                    .setId(response.getId() == null ? "" : response.getId())
-                    .setErrMsg(response.getErr() == null ? "" : response.getErr())
-                    .setSuccess(response.getSuccess())
-                    .build());
-        });
+        responses
+                .getResponses()
+                .forEach(response -> responseBuilder.addResults(SinkOuterClass.SinkResponse.Result
+                        .newBuilder()
+                        .setId(response.getId() == null ? "":response.getId())
+                        .setErrMsg(response.getErr() == null ? "":response.getErr())
+                        .setSuccess(response.getSuccess())
+                        .build()));
         return responseBuilder.build();
     }
 }

--- a/src/main/java/io/numaproj/numaflow/sinker/Sinker.java
+++ b/src/main/java/io/numaproj/numaflow/sinker/Sinker.java
@@ -8,21 +8,11 @@ package io.numaproj.numaflow.sinker;
 
 public abstract class Sinker {
     /**
-     * method will be used for processing messages.
-     * response for the message should be added to the
-     * response list which will be returned by getResponse
-     * @param datum current message to be processed
+     * Process a message and return a response.
+     *
+     * @param datum current message to be processed.
+     *
+     * @return response indicating whether the message processing is successful or not.
      */
-    public abstract void processMessage(Datum datum);
-
-    /**
-     * method will be used for returning the responses.
-     * each message should have a response, if there are
-     * n messages then there should be n responses and
-     * each response should contain the id of the message
-     * Response.responseOK() and Response.responseFailure() can
-     * be used for creating the responses
-     * @return ResponseList which contains the responses
-     */
-    public abstract ResponseList getResponse();
+    public abstract Response processMessage(Datum datum);
 }

--- a/src/test/java/io/numaproj/numaflow/sinker/ServerErrTest.java
+++ b/src/test/java/io/numaproj/numaflow/sinker/ServerErrTest.java
@@ -65,14 +65,16 @@ public class ServerErrTest {
         SinkOutputStreamObserver outputStreamObserver = new SinkOutputStreamObserver();
 
         Thread t = new Thread(() -> {
-            while (outputStreamObserver.t == null){
+            while (outputStreamObserver.t == null) {
                 try {
                     Thread.sleep(100);
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                 }
             }
-            assertEquals("UNKNOWN: java.lang.RuntimeException: unknown exception", outputStreamObserver.t.getMessage());
+            assertEquals(
+                    "UNKNOWN: java.lang.RuntimeException: unknown exception",
+                    outputStreamObserver.t.getMessage());
         });
         t.start();
 
@@ -109,13 +111,8 @@ public class ServerErrTest {
     private static class TestSinkFnErr extends Sinker {
 
         @Override
-        public void processMessage(Datum datum) {
+        public Response processMessage(Datum datum) {
             throw new RuntimeException("unknown exception");
-        }
-
-        @Override
-        public ResponseList getResponse() {
-            return null;
         }
     }
 }

--- a/src/test/java/io/numaproj/numaflow/sinker/ServerTest.java
+++ b/src/test/java/io/numaproj/numaflow/sinker/ServerTest.java
@@ -89,12 +89,12 @@ public class ServerTest {
 
         inputStreamObserver.onCompleted();
 
-        while(!outputStreamObserver.completed.get());
+        while (!outputStreamObserver.completed.get()) ;
         SinkOuterClass.SinkResponse responseList = outputStreamObserver.getSinkResponse();
         assertEquals(100, responseList.getResultsCount());
-        responseList.getResultsList().forEach((response -> {
-            assertEquals(response.getId(), expectedId);
-        }));
+        responseList
+                .getResultsList()
+                .forEach((response -> assertEquals(response.getId(), expectedId)));
 
         assertEquals(
                 responseList.getResults(responseList.getResultsCount() - 1).getErrMsg(),
@@ -103,23 +103,15 @@ public class ServerTest {
 
     @Slf4j
     private static class TestSinkFn extends Sinker {
-
-        private ResponseList.ResponseListBuilder builder = ResponseList.newBuilder();
         @Override
-        public void processMessage(Datum datum) {
+        public Response processMessage(Datum datum) {
             if (Arrays.equals(datum.getKeys(), new String[]{"invalid-key"})) {
-                builder.addResponse(Response.responseFailure(
+                return Response.responseFailure(
                         datum.getId() + processedIdSuffix,
-                        "error message"));
-                return;
+                        "error message");
             }
             log.info(new String(datum.getValue()));
-            builder.addResponse(Response.responseOK(datum.getId() + processedIdSuffix));
-        }
-
-        @Override
-        public ResponseList getResponse() {
-            return builder.build();
+            return Response.responseOK(datum.getId() + processedIdSuffix);
         }
     }
 }


### PR DESCRIPTION
Remove `getResponse` from the sinker and let the SinkActor take care of collecting responses and cleaning up the response list. Such that sinker implementers can focus on the processing logic without worrying about how the messages are managed at the back end.

This is a back-ward incompatible change, meaning existing users need to update their UDSinks to accommodate this SDK upgrade. But I think it's worth it. Also we don't have many udsinks written in JAVA yet afaik.