### PR TITLE
chore: unify the event time of messages to drop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ buildNumber.properties
 
 # IDE
 .vscode/
+.DS_Store
+*/**/.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.26</version>
+            <version>1.18.30</version>
             <scope>compile</scope>
         </dependency>
 

--- a/src/main/java/io/numaproj/numaflow/sourcetransformer/Message.java
+++ b/src/main/java/io/numaproj/numaflow/sourcetransformer/Message.java
@@ -11,8 +11,11 @@ import java.time.Instant;
 @Getter
 public class Message {
     public static final String DROP = "U+005C__DROP__";
-
-
+    // epoch second -86400 translates to UTC time 1969-12-31 00:00:00 +0000 UTC,
+    // EventTimeForDrop is set to be slightly earlier than Unix epoch -1 (1969-12-31 23:59:59.999 +0000 UTC)
+    // As -1 is used on Numaflow to indicate watermark is not available,
+    // EventTimeForDrop is used to indicate that the message is dropped hence, excluded from watermark calculation
+    public static final Instant EventTimeForDrop = Instant.ofEpochSecond(-86400);
     private final String[] keys;
     private final byte[] value;
     private final Instant eventTime;
@@ -60,6 +63,10 @@ public class Message {
      * @return returns the Message which will be dropped
      */
     public static Message toDrop() {
-        return new Message(new byte[0], Instant.MIN, null, new String[]{DROP});
+        return new Message(
+                new byte[0],
+                EventTimeForDrop,
+                null,
+                new String[]{DROP});
     }
 }

--- a/src/main/java/io/numaproj/numaflow/sourcetransformer/Message.java
+++ b/src/main/java/io/numaproj/numaflow/sourcetransformer/Message.java
@@ -11,11 +11,9 @@ import java.time.Instant;
 @Getter
 public class Message {
     public static final String DROP = "U+005C__DROP__";
-    // epoch second -86400 translates to UTC time 1969-12-31 00:00:00 +0000 UTC,
-    // EventTimeForDrop is set to be slightly earlier than Unix epoch -1 (1969-12-31 23:59:59.999 +0000 UTC)
-    // As -1 is used on Numaflow to indicate watermark is not available,
+    // Watermark are at millisecond granularity, hence we use epoch(0) - 1 to indicate watermark is not available.
     // EventTimeForDrop is used to indicate that the message is dropped hence, excluded from watermark calculation
-    public static final Instant EventTimeForDrop = Instant.ofEpochSecond(-86400);
+    private static final Instant EventTimeForDrop = Instant.ofEpochMilli(-1);
     private final String[] keys;
     private final byte[] value;
     private final Instant eventTime;


### PR DESCRIPTION
Set the event time of messages to drop to epoch(0) - 1ms across all our SDKs.