### PR TITLE
chore: update to version 0.6.1 for the server info changes

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>io.numaproj.numaflow</groupId>
             <artifactId>numaflow-java</artifactId>
-            <version>0.6.0</version>
+            <version>0.6.1</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.numaproj.numaflow</groupId>
     <artifactId>numaflow-java</artifactId>
-    <version>0.6.0</version>
+    <version>0.6.1</version>
     <packaging>jar</packaging>
 
     <name>numaflow-java</name>


### PR DESCRIPTION
update to version 0.6.1 as new images with the server info changes use this version, relates to [#1456](https://github.com/numaproj/numaflow/issues/1456)