### PR TITLE
chore: remove unnecessary flag

### DIFF
--- a/development.md
+++ b/development.md
@@ -24,7 +24,7 @@ The default tag is `stable`, but it is recommended you specify your own for test
 This consistent tag name is used so that the tags in the [E2E test pipelines](https://github.com/numaproj/numaflow/tree/main/test) do not need to be
 updated each time an SDK change is made.
 
-`-bpe`first builds a local image with the naming convention 
+`-bpe` first builds a local image with the naming convention 
 `numaflow-java-examples/<example-execution-id>:<tag>`, which then gets pushed as 
 `quay.io/numaio/numaflow-java/<example-execution-id>:<tag>`. If you want to build and tag all images locally, 
 without pushing to quay.io, as mentioned in step 3, run: `mvn clean install -Ddocker.tag=<tag>`.

--- a/development.md
+++ b/development.md
@@ -16,19 +16,15 @@ directories match)
 and then build all example images. Now that the images are available locally,
 you can take the desired image and test it in a pipeline
 
-If you want to build and push all the example images at once, you can run:
+You can build and push a specific example image by running the following:
 ```shell
-./hack/update_examples.sh -bp -t <tag>
-```
+./hack/update_examples.sh -bpe <example-execution-id> -t <tag>
+ ```
 The default tag is `stable`, but it is recommended you specify your own for testing purposes, as the Github Actions CI uses the `stable` tag.
 This consistent tag name is used so that the tags in the [E2E test pipelines](https://github.com/numaproj/numaflow/tree/main/test) do not need to be
 updated each time an SDK change is made.
 
-You can alternatively build and push a specific example image by running the following:
-```shell
-./hack/update_examples.sh -bpe <example-execution-id> -t <tag>
- ```
-Both `-bpe` and `-bp` first build a local image with the naming convention 
+`-bpe`first builds a local image with the naming convention 
 `numaflow-java-examples/<example-execution-id>:<tag>`, which then gets pushed as 
 `quay.io/numaio/numaflow-java/<example-execution-id>:<tag>`. If you want to build and tag all images locally, 
 without pushing to quay.io, as mentioned in step 3, run: `mvn clean install -Ddocker.tag=<tag>`.

--- a/hack/update_examples.sh
+++ b/hack/update_examples.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
 function show_help () {
-    echo "Usage: $0 [-h|--help | -t|--tag <tag>] (-bp|--build-push | -bpe|--build-push-example <execution-id>)"
+    echo "Usage: $0 [-h|--help | -t|--tag <tag>] (-bpe|--build-push-example <execution-id>)"
     echo "  -h, --help                   Display help message and exit"
-    echo "  -bp, --build-push            Build all the examples and push them to the quay.io registry"
     echo "  -bpe, --build-push-example   Build the given example id (found in examples/pom.xml), and push it to the quay.io registry"
     echo "  -t, --tag                    To be optionally used with -bpe or -bp. Specify the tag to build with. Default tag: stable"
 }
@@ -15,7 +14,6 @@ if [ $# -eq 0 ]; then
 fi
 
 usingHelp=0
-usingBuildPush=0
 usingBuildPushExample=0
 usingTag=0
 executionID=""
@@ -26,9 +24,6 @@ function handle_options () {
     case "$1" in
       -h | --help)
         usingHelp=1
-        ;;
-      -bp | --build-push)
-        usingBuildPush=1
         ;;
       -bpe | --build-push-example)
         if [ -z "$2" ]; then
@@ -64,14 +59,14 @@ function handle_options () {
 
 handle_options "$@"
 
-if (( usingBuildPush + usingBuildPushExample + usingHelp > 1 )); then
-  echo "Only one of '-h', '-bp', or '-bpe' is allowed at a time" >&2
+if (( usingBuildPushExample + usingHelp > 1 )); then
+  echo "Only one of '-h' or '-bpe' is allowed at a time" >&2
   show_help
   exit 1
 fi
 
-if (( (usingTag + usingHelp > 1) || (usingTag && usingBuildPush + usingBuildPushExample == 0) )); then
-  echo "Can only use -t with -bp or -bpe" >&2
+if (( (usingTag + usingHelp > 1) || (usingTag && usingBuildPushExample == 0) )); then
+  echo "Can only use -t with -bpe" >&2
   show_help
   exit 1
 fi
@@ -114,13 +109,7 @@ function build () {
   fi
 }
 
-if (( usingBuildPush )); then
-  build
-  for id in "${executionIDs[@]}"
-  do
-    dockerPublish "$id"
-  done
-elif (( usingBuildPushExample )); then
+if (( usingBuildPushExample )); then
   build
   dockerPublish "$executionID"
 elif (( usingHelp )); then


### PR DESCRIPTION
It is very unlikely that anyone will ever need to build and push all the example images locally while testing. In order to clean up the script remove this functionality, as it should only be done by Github Actions workflow.