### PR TITLE
fix: update netty and GRPC version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <protobuf.version>3.21.8</protobuf.version>
-        <grpc.version>1.59.0</grpc.version>
-        <netty.version>4.1.108.Final</netty.version> <!-- match version grpc-netty depends on -->
+        <grpc.version>1.65.0</grpc.version>
+        <netty.version>4.1.111.Final</netty.version> <!-- match version grpc-netty depends on -->
         <akka.version>2.8.5</akka.version>
         <slf4j.version>2.0.7</slf4j.version>
     </properties>


### PR DESCRIPTION
grpc-netty breaks with netty version 4.1.111. grpc-netty version 1.65.0 fixes this issue

Issue tracker: https://github.com/grpc/grpc-java/issues/11284
