### PR TITLE
chore: release version 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add this dependency to your project's POM:
 <dependency>
   <groupId>io.numaproj.numaflow</groupId>
   <artifactId>numaflow-java</artifactId>
-  <version>0.7.4</version>
+  <version>0.8.0</version>
 </dependency>
 ```
 
@@ -35,7 +35,7 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "io.numaproj.numaflow:numaflow-java:0.7.4"
+compile "io.numaproj.numaflow:numaflow-java:0.8.0"
 ```
 
 ### Build

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.numaproj.numaflow</groupId>
             <artifactId>numaflow-java</artifactId>
-            <version>0.7.4</version>
+            <version>0.8.0</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.numaproj.numaflow</groupId>
     <artifactId>numaflow-java</artifactId>
-    <version>0.7.4</version>
+    <version>0.8.0</version>
     <packaging>jar</packaging>
 
     <name>numaflow-java</name>

--- a/src/main/java/io/numaproj/numaflow/info/ServerInfo.java
+++ b/src/main/java/io/numaproj/numaflow/info/ServerInfo.java
@@ -22,7 +22,7 @@ import java.util.Map;
 @AllArgsConstructor
 public class ServerInfo {
     // Specify the minimum Numaflow version required by the current SDK version
-    public static final String MINIMUM_NUMAFLOW_VERSION = "1.2.0-rc4";
+    public static final String MINIMUM_NUMAFLOW_VERSION = "1.3.0-rc1";
     @JsonProperty("protocol")
     private Protocol protocol;
     @JsonProperty("language")


### PR DESCRIPTION
I updated the compatible version of numaflow to 1.3.0-rc1 mainly because of batch map. If a user wants to use it, the user has to be on 1.3.0-rc1. If a user wants to upgrade an existing pipeline to use Java SDK 0.8.0, the controller must be upgraded first.