### PR TITLE
fix: server not stopping locally

### DIFF
--- a/src/main/java/io/numaproj/numaflow/batchmapper/Server.java
+++ b/src/main/java/io/numaproj/numaflow/batchmapper/Server.java
@@ -72,17 +72,19 @@ public class Server {
 
         log.info("server started, listening on socket path: {}", this.grpcConfig.getSocketPath());
 
-        // register shutdown hook to gracefully shut down the server
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            // Use stderr here since the logger may have been reset by its JVM shutdown hook.
-            System.err.println("*** shutting down gRPC server since JVM is shutting down");
-            try {
-                this.stop();
-            } catch (InterruptedException e) {
-                Thread.interrupted();
-                e.printStackTrace(System.err);
-            }
-        }));
+        if (!this.grpcConfig.isLocal()) {
+            // register shutdown hook to gracefully shut down the server
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                // Use stderr here since the logger may have been reset by its JVM shutdown hook.
+                System.err.println("*** shutting down gRPC server since JVM is shutting down");
+                try {
+                    this.stop();
+                } catch (InterruptedException e) {
+                    Thread.interrupted();
+                    e.printStackTrace(System.err);
+                }
+            }));
+        }
 
         // if there are any exceptions, shutdown the server gracefully.
         this.shutdownSignal.whenCompleteAsync((v, e) -> {

--- a/src/main/java/io/numaproj/numaflow/mapper/Server.java
+++ b/src/main/java/io/numaproj/numaflow/mapper/Server.java
@@ -70,6 +70,21 @@ public class Server {
                     this.grpcConfig.getInfoFilePath(),
                     ContainerType.MAPPER,
                     Collections.singletonMap(Constants.MAP_MODE_KEY, Constants.MAP_MODE));
+
+            // register shutdown hook to gracefully shut down the server
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                // Use stderr here since the logger may have been reset by its JVM shutdown hook.
+                System.err.println("*** shutting down gRPC server since JVM is shutting down");
+                try {
+                    this.stop();
+                    // FIXME - this is a workaround to immediately terminate the JVM process
+                    // The correct way to do this is to stop all the actors and wait for them to terminate
+                    System.exit(0);
+                } catch (InterruptedException e) {
+                    Thread.interrupted();
+                    e.printStackTrace(System.err);
+                }
+            }));
         }
 
         this.server.start();
@@ -78,21 +93,6 @@ public class Server {
                 "server started, listening on {}",
                 this.grpcConfig.isLocal() ?
                         "localhost:" + this.grpcConfig.getPort() : this.grpcConfig.getSocketPath());
-
-        // register shutdown hook to gracefully shut down the server
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            // Use stderr here since the logger may have been reset by its JVM shutdown hook.
-            System.err.println("*** shutting down gRPC server since JVM is shutting down");
-            try {
-                this.stop();
-                // FIXME - this is a workaround to immediately terminate the JVM process
-                // The correct way to do this is to stop all the actors and wait for them to terminate
-                System.exit(0);
-            } catch (InterruptedException e) {
-                Thread.interrupted();
-                e.printStackTrace(System.err);
-            }
-        }));
 
         // if there are any exceptions, shutdown the server gracefully.
         this.shutdownSignal.whenCompleteAsync((v, e) -> {

--- a/src/main/java/io/numaproj/numaflow/mapstreamer/Server.java
+++ b/src/main/java/io/numaproj/numaflow/mapstreamer/Server.java
@@ -72,17 +72,19 @@ public class Server {
 
         log.info("server started, listening on socket path: {}", this.grpcConfig.getSocketPath());
 
-        // register shutdown hook to gracefully shut down the server
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            // Use stderr here since the logger may have been reset by its JVM shutdown hook.
-            System.err.println("*** shutting down map streamer gRPC server since JVM is shutting down");
-            try {
-                this.stop();
-            } catch (InterruptedException e) {
-                Thread.interrupted();
-                e.printStackTrace(System.err);
-            }
-        }));
+        if (!this.grpcConfig.isLocal()) {
+            // register shutdown hook to gracefully shut down the server
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                // Use stderr here since the logger may have been reset by its JVM shutdown hook.
+                System.err.println("*** shutting down map streamer gRPC server since JVM is shutting down");
+                try {
+                    this.stop();
+                } catch (InterruptedException e) {
+                    Thread.interrupted();
+                    e.printStackTrace(System.err);
+                }
+            }));
+        }
 
         // if there are any exceptions, shutdown the server gracefully.
         this.shutdownSignal.whenCompleteAsync((v, e) -> {

--- a/src/main/java/io/numaproj/numaflow/reducer/Server.java
+++ b/src/main/java/io/numaproj/numaflow/reducer/Server.java
@@ -61,6 +61,18 @@ public class Server {
                     this.grpcConfig.getSocketPath(),
                     this.grpcConfig.getInfoFilePath(),
                     ContainerType.REDUCER);
+
+            // register shutdown hook to gracefully shut down the server
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                // Use stderr here since the logger may have been reset by its JVM shutdown hook.
+                System.err.println("*** shutting down gRPC server since JVM is shutting down");
+                try {
+                    this.stop();
+                } catch (InterruptedException e) {
+                    Thread.interrupted();
+                    e.printStackTrace(System.err);
+                }
+            }));
         }
 
         this.server.start();
@@ -69,18 +81,6 @@ public class Server {
                 "server started, listening on {}",
                 grpcConfig.isLocal() ?
                         "localhost:" + grpcConfig.getPort() : grpcConfig.getSocketPath());
-
-        // register shutdown hook to gracefully shut down the server
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            // Use stderr here since the logger may have been reset by its JVM shutdown hook.
-            System.err.println("*** shutting down gRPC server since JVM is shutting down");
-            try {
-                this.stop();
-            } catch (InterruptedException e) {
-                Thread.interrupted();
-                e.printStackTrace(System.err);
-            }
-        }));
     }
 
     /**

--- a/src/main/java/io/numaproj/numaflow/reducestreamer/Server.java
+++ b/src/main/java/io/numaproj/numaflow/reducestreamer/Server.java
@@ -64,6 +64,18 @@ public class Server {
                     this.grpcConfig.getSocketPath(),
                     this.grpcConfig.getInfoFilePath(),
                     ContainerType.REDUCE_STREAMER);
+
+            // register shutdown hook to gracefully shut down the server
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                // Use stderr here since the logger may have been reset by its JVM shutdown hook.
+                System.err.println("*** shutting down gRPC server since JVM is shutting down");
+                try {
+                    this.stop();
+                } catch (InterruptedException e) {
+                    Thread.interrupted();
+                    e.printStackTrace(System.err);
+                }
+            }));
         }
 
         this.server.start();
@@ -72,18 +84,6 @@ public class Server {
                 "server started, listening on {}",
                 this.grpcConfig.isLocal() ?
                         "localhost:" + this.grpcConfig.getPort() : this.grpcConfig.getSocketPath());
-
-        // register shutdown hook to gracefully shut down the server
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            // Use stderr here since the logger may have been reset by its JVM shutdown hook.
-            System.err.println("*** shutting down gRPC server since JVM is shutting down");
-            try {
-                this.stop();
-            } catch (InterruptedException e) {
-                Thread.interrupted();
-                e.printStackTrace(System.err);
-            }
-        }));
     }
 
     /**

--- a/src/main/java/io/numaproj/numaflow/servingstore/Server.java
+++ b/src/main/java/io/numaproj/numaflow/servingstore/Server.java
@@ -76,6 +76,19 @@ public class Server {
                     this.grpcConfig.getSocketPath(),
                     this.grpcConfig.getInfoFilePath(),
                     ContainerType.SERVING);
+
+            // register shutdown hook to gracefully shut down the server
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                // Use stderr here since the logger may have been reset by its JVM shutdown
+                // hook.
+                System.err.println("*** shutting down gRPC server since JVM is shutting down");
+                try {
+                    this.stop();
+                } catch (InterruptedException e) {
+                    Thread.interrupted();
+                    e.printStackTrace(System.err);
+                }
+            }));
         }
 
         this.server.start();
@@ -84,19 +97,6 @@ public class Server {
                 "server started, listening on {}",
                 this.grpcConfig.isLocal() ?
                         "localhost:" + this.grpcConfig.getPort() : this.grpcConfig.getSocketPath());
-
-        // register shutdown hook to gracefully shut down the server
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            // Use stderr here since the logger may have been reset by its JVM shutdown
-            // hook.
-            System.err.println("*** shutting down gRPC server since JVM is shutting down");
-            try {
-                this.stop();
-            } catch (InterruptedException e) {
-                Thread.interrupted();
-                e.printStackTrace(System.err);
-            }
-        }));
 
         // if there are any exceptions, shutdown the server gracefully.
         this.shutdownSignal.whenCompleteAsync((v, e) -> {

--- a/src/main/java/io/numaproj/numaflow/sessionreducer/Server.java
+++ b/src/main/java/io/numaproj/numaflow/sessionreducer/Server.java
@@ -64,6 +64,18 @@ public class Server {
                     this.grpcConfig.getSocketPath(),
                     this.grpcConfig.getInfoFilePath(),
                     ContainerType.SESSION_REDUCER);
+
+            // register shutdown hook to gracefully shut down the server
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                // Use stderr here since the logger may have been reset by its JVM shutdown hook.
+                System.err.println("*** shutting down gRPC server since JVM is shutting down");
+                try {
+                    this.stop();
+                } catch (InterruptedException e) {
+                    Thread.interrupted();
+                    e.printStackTrace(System.err);
+                }
+            }));
         }
 
         this.server.start();
@@ -72,18 +84,6 @@ public class Server {
                 "server started, listening on {}",
                 this.grpcConfig.isLocal() ?
                         "localhost:" + this.grpcConfig.getPort() : this.grpcConfig.getSocketPath());
-
-        // register shutdown hook to gracefully shut down the server
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            // Use stderr here since the logger may have been reset by its JVM shutdown hook.
-            System.err.println("*** shutting down gRPC server since JVM is shutting down");
-            try {
-                this.stop();
-            } catch (InterruptedException e) {
-                Thread.interrupted();
-                e.printStackTrace(System.err);
-            }
-        }));
     }
 
     /**

--- a/src/main/java/io/numaproj/numaflow/sideinput/Server.java
+++ b/src/main/java/io/numaproj/numaflow/sideinput/Server.java
@@ -62,6 +62,17 @@ public class Server {
                     this.grpcConfig.getSocketPath(),
                     this.grpcConfig.getInfoFilePath(),
                     ContainerType.SIDEINPUT);
+
+            // register shutdown hook to gracefully shut down the server
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                // Use stderr here since the logger may have been reset by its JVM shutdown hook.
+                try {
+                    this.stop();
+                } catch (InterruptedException e) {
+                    Thread.interrupted();
+                    e.printStackTrace(System.err);
+                }
+            }));
         }
 
         this.server.start();
@@ -69,17 +80,6 @@ public class Server {
         log.info(
                 "server started, listening on {}",
                 this.grpcConfig.isLocal() ? "localhost:" + this.grpcConfig.getPort() : this.grpcConfig.getSocketPath());
-
-        // register shutdown hook to gracefully shut down the server
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            // Use stderr here since the logger may have been reset by its JVM shutdown hook.
-            try {
-                this.stop();
-            } catch (InterruptedException e) {
-                Thread.interrupted();
-                e.printStackTrace(System.err);
-            }
-        }));
     }
 
     /**

--- a/src/main/java/io/numaproj/numaflow/sourcetransformer/Server.java
+++ b/src/main/java/io/numaproj/numaflow/sourcetransformer/Server.java
@@ -66,6 +66,21 @@ public class Server {
                     this.grpcConfig.getSocketPath(),
                     this.grpcConfig.getInfoFilePath(),
                     ContainerType.SOURCE_TRANSFORMER);
+
+            // register shutdown hook to gracefully shut down the server
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                // Use stderr here since the logger may have been reset by its JVM shutdown hook.
+                System.err.println("*** shutting down gRPC server since JVM is shutting down");
+                try {
+                    this.stop();
+                    // FIXME - this is a workaround to immediately terminate the JVM process
+                    // The correct way to do this is to stop all the actors and wait for them to terminate
+                    System.exit(0);
+                } catch (InterruptedException e) {
+                    Thread.interrupted();
+                    e.printStackTrace(System.err);
+                }
+            }));
         }
 
         this.server.start();
@@ -74,21 +89,6 @@ public class Server {
                 "server started, listening on {}",
                 this.grpcConfig.isLocal() ?
                         "localhost:" + this.grpcConfig.getPort() : this.grpcConfig.getSocketPath());
-
-        // register shutdown hook to gracefully shut down the server
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            // Use stderr here since the logger may have been reset by its JVM shutdown hook.
-            System.err.println("*** shutting down gRPC server since JVM is shutting down");
-             try {
-                this.stop();
-                // FIXME - this is a workaround to immediately terminate the JVM process
-                // The correct way to do this is to stop all the actors and wait for them to terminate
-                System.exit(0);
-            } catch (InterruptedException e) {
-                Thread.interrupted();
-                e.printStackTrace(System.err);
-            }
-        }));
 
         // if there are any exceptions, shutdown the server gracefully.
         this.shutdownSignal.whenCompleteAsync((v, e) -> {


### PR DESCRIPTION
This is caused by shutdown hooks that are added to perform cleanups on exit. However, when running it locally, they keep waiting for a SIGKILL and prevent regular shutdown. This is causing all integration tests to keep running indefinitely and never pass or fail.

Tested working locally.