### PR TITLE
refactor: apply some Java best practices

### DIFF
--- a/src/main/java/io/numaproj/numaflow/accumulator/Constants.java
+++ b/src/main/java/io/numaproj/numaflow/accumulator/Constants.java
@@ -1,19 +1,18 @@
 package io.numaproj.numaflow.accumulator;
 
 class Constants {
-    public static final String SUCCESS = "SUCCESS";
+  public static final String SUCCESS = "SUCCESS";
+  public static final String DELIMITER = ":";
+  public static final int DEFAULT_MESSAGE_SIZE = 1024 * 1024 * 64;
+  public static final String DEFAULT_SOCKET_PATH = "/var/run/numaflow/accumulator.sock";
+  public static final String DEFAULT_SERVER_INFO_FILE_PATH =
+      "/var/run/numaflow/accumulator-server-info";
+  public static final int DEFAULT_PORT = 50051;
+  public static final String DEFAULT_HOST = "localhost";
+  public static final String EOF = "EOF";
 
-    public static final String DELIMITER = ":";
-
-    public static final int DEFAULT_MESSAGE_SIZE = 1024 * 1024 * 64;
-
-    public static final String DEFAULT_SOCKET_PATH = "/var/run/numaflow/accumulator.sock";
-
-    public static final String DEFAULT_SERVER_INFO_FILE_PATH = "/var/run/numaflow/accumulator-server-info";
-
-    public static final int DEFAULT_PORT = 50051;
-
-    public static final String DEFAULT_HOST = "localhost";
-
-    public static final String EOF = "EOF";
+  // Private constructor to prevent instantiation
+  private Constants() {
+    throw new IllegalStateException("Utility class 'Constants' should not be instantiated");
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/accumulator/model/Message.java
+++ b/src/main/java/io/numaproj/numaflow/accumulator/model/Message.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 /** Message is used to wrap the data returned by Accumulator functions. */
 @Getter
-public final class Message {
+public class Message {
   private final Instant eventTime;
   private final Instant watermark;
   private final Map<String, String> headers;

--- a/src/main/java/io/numaproj/numaflow/accumulator/model/Message.java
+++ b/src/main/java/io/numaproj/numaflow/accumulator/model/Message.java
@@ -1,65 +1,61 @@
 package io.numaproj.numaflow.accumulator.model;
 
-import lombok.Getter;
-
 import java.time.Instant;
 import java.util.Map;
+import lombok.Getter;
 
-/**
- * Message is used to wrap the data returned by Accumulator functions.
- */
+/** Message is used to wrap the data returned by Accumulator functions. */
 @Getter
-public class Message {
-    private final Instant eventTime;
-    private final Instant watermark;
-    private final Map<String, String> headers;
-    private final String id;
-    private String[] keys;
-    private byte[] value;
-    private String[] tags;
+public final class Message {
+  private final Instant eventTime;
+  private final Instant watermark;
+  private final Map<String, String> headers;
+  private final String id;
+  private String[] keys;
+  private byte[] value;
+  private String[] tags;
 
-    /**
-     * Constructor for constructing message from Datum, it is advised to use the
-     * incoming Datum to construct the message, because event time, watermark, id
-     * and headers of the message are derived from the Datum. Only use custom
-     * implementation of the Datum if you know what you are doing.
-     *
-     * @param datum {@link Datum} object
-     */
-    public Message(Datum datum) {
-        this.keys = datum.getKeys();
-        this.value = datum.getValue();
-        this.headers = datum.getHeaders();
-        this.eventTime = datum.getEventTime();
-        this.watermark = datum.getWatermark();
-        this.id = datum.getID();
-        this.tags = null;
-    }
+  /**
+   * Constructor for constructing message from Datum, it is advised to use the incoming Datum to
+   * construct the message, because event time, watermark, id and headers of the message are derived
+   * from the Datum. Only use custom implementation of the Datum if you know what you are doing.
+   *
+   * @param datum {@link Datum} object
+   */
+  public Message(Datum datum) {
+    this.keys = datum.getKeys();
+    this.value = datum.getValue();
+    this.headers = datum.getHeaders();
+    this.eventTime = datum.getEventTime();
+    this.watermark = datum.getWatermark();
+    this.id = datum.getID();
+    this.tags = null;
+  }
 
-    /*
-     * sets the value of the message
-     *
-     * @param value byte array of the value
-     */
-    public void setValue(byte[] value) {
-        this.value = value;
-    }
+  /*
+   * sets the value of the message
+   *
+   * @param value byte array of the value
+   */
+  public void setValue(byte[] value) {
+    this.value = value;
+  }
 
-    /*
-     * sets the keys of the message
-     *
-     * @param keys string array of the keys
-     */
-    public void setKeys(String[] keys) {
-        this.keys = keys;
-    }
+  /*
+   * sets the keys of the message
+   *
+   * @param keys string array of the keys
+   */
+  public void setKeys(String[] keys) {
+    this.keys = keys;
+  }
 
-    /*
-     * sets the tags of the message, tags are used for conditional forwarding
-     *
-     * @param tags string array of the tags
-     */
-    public void setTags(String[] tags) {
-        this.tags = tags;
-    }
+  /*
+   * sets the tags of the message, tags are used for conditional forwarding
+   *
+   * @param tags string array of the tags
+   */
+  public void setTags(String[] tags) {
+    this.tags = tags;
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/batchmapper/Constants.java
+++ b/src/main/java/io/numaproj/numaflow/batchmapper/Constants.java
@@ -1,20 +1,17 @@
 package io.numaproj.numaflow.batchmapper;
 
 class Constants {
-    public static final int DEFAULT_MESSAGE_SIZE = 1024 * 1024 * 64;
+  public static final int DEFAULT_MESSAGE_SIZE = 1024 * 1024 * 64;
+  public static final String DEFAULT_SOCKET_PATH = "/var/run/numaflow/batchmap.sock";
+  public static final String DEFAULT_SERVER_INFO_FILE_PATH = "/var/run/numaflow/mapper-server-info";
+  public static final int DEFAULT_PORT = 50051;
+  public static final String DEFAULT_HOST = "localhost";
+  public static final String SUCCESS = "SUCCESS";
+  public static final String MAP_MODE_KEY = "MAP_MODE";
+  public static final String MAP_MODE = "batch-map";
 
-    public static final String DEFAULT_SOCKET_PATH = "/var/run/numaflow/batchmap.sock";
-
-    public static final String DEFAULT_SERVER_INFO_FILE_PATH = "/var/run/numaflow/mapper-server-info";
-
-    public static final int DEFAULT_PORT = 50051;
-
-    public static final String DEFAULT_HOST = "localhost";
-
-    public static final String SUCCESS = "SUCCESS";
-
-    public static final String MAP_MODE_KEY = "MAP_MODE";
-
-    public static final String MAP_MODE = "batch-map";
+  // Private constructor to prevent instantiation
+  private Constants() {
+    throw new IllegalStateException("Utility class 'Constants' should not be instantiated");
+  }
 }
-

--- a/src/main/java/io/numaproj/numaflow/batchmapper/Message.java
+++ b/src/main/java/io/numaproj/numaflow/batchmapper/Message.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 /** Message is used to wrap the data returned by Mapper. */
 @Getter(AccessLevel.PROTECTED)
-public class Message {
+public final class Message {
   private static final String[] DROP_TAGS = {"U+005C__DROP__"};
   private final String[] keys;
   private final byte[] value;

--- a/src/main/java/io/numaproj/numaflow/batchmapper/Message.java
+++ b/src/main/java/io/numaproj/numaflow/batchmapper/Message.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 /** Message is used to wrap the data returned by Mapper. */
 @Getter
-public final class Message {
+public class Message {
   private static final String[] DROP_TAGS = {"U+005C__DROP__"};
   private final String[] keys;
   private final byte[] value;

--- a/src/main/java/io/numaproj/numaflow/batchmapper/Message.java
+++ b/src/main/java/io/numaproj/numaflow/batchmapper/Message.java
@@ -19,9 +19,10 @@ public class Message {
    * @param tags message tags which will be used for conditional forwarding
    */
   public Message(byte[] value, String[] keys, String[] tags) {
-    this.keys = keys;
-    this.value = value;
-    this.tags = tags;
+    // defensive copy - once the Message is created, the caller should not be able to modify it.
+    this.keys = keys == null ? null : keys.clone();
+    this.value = value == null ? null : value.clone();
+    this.tags = tags == null ? null : tags.clone();
   }
 
   /**

--- a/src/main/java/io/numaproj/numaflow/batchmapper/Message.java
+++ b/src/main/java/io/numaproj/numaflow/batchmapper/Message.java
@@ -1,13 +1,12 @@
 package io.numaproj.numaflow.batchmapper;
 
-import lombok.Getter;
 import lombok.AccessLevel;
+import lombok.Getter;
 
 /** Message is used to wrap the data returned by Mapper. */
 @Getter(AccessLevel.PROTECTED)
 public class Message {
-  public static final String DROP = "U+005C__DROP__";
-
+  private static final String[] DROP_TAGS = {"U+005C__DROP__"};
   private final String[] keys;
   private final byte[] value;
   private final String[] tags;
@@ -50,6 +49,6 @@ public class Message {
    * @return returns the Message which will be dropped
    */
   public static Message toDrop() {
-    return new Message(new byte[0], null, new String[] {DROP});
+    return new Message(new byte[0], null, DROP_TAGS);
   }
 }

--- a/src/main/java/io/numaproj/numaflow/batchmapper/Message.java
+++ b/src/main/java/io/numaproj/numaflow/batchmapper/Message.java
@@ -1,58 +1,55 @@
 package io.numaproj.numaflow.batchmapper;
 
 import lombok.Getter;
+import lombok.AccessLevel;
 
-/**
- * Message is used to wrap the data returned by Mapper.
- */
-
-@Getter
+/** Message is used to wrap the data returned by Mapper. */
+@Getter(AccessLevel.PROTECTED)
 public class Message {
-    public static final String DROP = "U+005C__DROP__";
+  public static final String DROP = "U+005C__DROP__";
 
-    private final String[] keys;
-    private final byte[] value;
-    private final String[] tags;
+  private final String[] keys;
+  private final byte[] value;
+  private final String[] tags;
 
+  /**
+   * used to create Message with value, keys and tags(used for conditional forwarding)
+   *
+   * @param value message value
+   * @param keys message keys
+   * @param tags message tags which will be used for conditional forwarding
+   */
+  public Message(byte[] value, String[] keys, String[] tags) {
+    this.keys = keys;
+    this.value = value;
+    this.tags = tags;
+  }
 
-    /**
-     * used to create Message with value, keys and tags(used for conditional forwarding)
-     *
-     * @param value message value
-     * @param keys message keys
-     * @param tags message tags which will be used for conditional forwarding
-     */
-    public Message(byte[] value, String[] keys, String[] tags) {
-        this.keys = keys;
-        this.value = value;
-        this.tags = tags;
-    }
+  /**
+   * used to create Message with value.
+   *
+   * @param value message value
+   */
+  public Message(byte[] value) {
+    this(value, null, null);
+  }
 
-    /**
-     * used to create Message with value.
-     *
-     * @param value message value
-     */
-    public Message(byte[] value) {
-        this(value, null, null);
-    }
+  /**
+   * used to create Message with value and keys.
+   *
+   * @param value message value
+   * @param keys message keys
+   */
+  public Message(byte[] value, String[] keys) {
+    this(value, keys, null);
+  }
 
-    /**
-     * used to create Message with value and keys.
-     *
-     * @param value message value
-     * @param keys message keys
-     */
-    public Message(byte[] value, String[] keys) {
-        this(value, keys, null);
-    }
-
-    /**
-     * creates a Message which will be dropped
-     *
-     * @return returns the Message which will be dropped
-     */
-    public static Message toDrop() {
-        return new Message(new byte[0], null, new String[]{DROP});
-    }
+  /**
+   * creates a Message which will be dropped
+   *
+   * @return returns the Message which will be dropped
+   */
+  public static Message toDrop() {
+    return new Message(new byte[0], null, new String[] {DROP});
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/batchmapper/Message.java
+++ b/src/main/java/io/numaproj/numaflow/batchmapper/Message.java
@@ -1,10 +1,9 @@
 package io.numaproj.numaflow.batchmapper;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 
 /** Message is used to wrap the data returned by Mapper. */
-@Getter(AccessLevel.PROTECTED)
+@Getter
 public final class Message {
   private static final String[] DROP_TAGS = {"U+005C__DROP__"};
   private final String[] keys;

--- a/src/main/java/io/numaproj/numaflow/info/ServerInfo.java
+++ b/src/main/java/io/numaproj/numaflow/info/ServerInfo.java
@@ -1,14 +1,13 @@
 package io.numaproj.numaflow.info;
 
+import static java.util.Map.entry;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import java.util.Map;
-
-import static java.util.Map.entry;
 
 /**
  * Server Information to be used by client to determine:
@@ -22,7 +21,7 @@ import static java.util.Map.entry;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class ServerInfo {
+public final class ServerInfo {
     // Specify the minimum Numaflow version required by the current SDK version
     // To update this value, please follow the instructions for
     // MINIMUM_NUMAFLOW_VERSION in

--- a/src/main/java/io/numaproj/numaflow/info/ServerInfoAccessor.java
+++ b/src/main/java/io/numaproj/numaflow/info/ServerInfoAccessor.java
@@ -1,8 +1,6 @@
 package io.numaproj.numaflow.info;
 
 public interface ServerInfoAccessor {
-    String INFO_EOF = "U+005C__END__";
-
     /**
      * Get current runtime numaflow-java SDK version.
      */
@@ -11,7 +9,6 @@ public interface ServerInfoAccessor {
     /**
      * Delete filePath if it exists.
      * Write serverInfo to filePath in Json format.
-     * Append {@link ServerInfoAccessor#INFO_EOF} as a new line to indicate end of file.
      *
      * @param serverInfo server information POJO
      * @param filePath file path to write to

--- a/src/main/java/io/numaproj/numaflow/info/ServerInfoAccessorImpl.java
+++ b/src/main/java/io/numaproj/numaflow/info/ServerInfoAccessorImpl.java
@@ -1,5 +1,7 @@
 package io.numaproj.numaflow.info;
 
+import static com.fasterxml.jackson.core.JsonGenerator.Feature.AUTO_CLOSE_TARGET;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.BufferedWriter;
 import java.io.FileWriter;
@@ -14,51 +16,54 @@ import lombok.extern.slf4j.Slf4j;
 @AllArgsConstructor
 @Slf4j
 public class ServerInfoAccessorImpl implements ServerInfoAccessor {
-    private ObjectMapper objectMapper;
-    private static final String INFO_EOF = "U+005C__END__";
+  private static final String INFO_EOF = "U+005C__END__";
+  private ObjectMapper objectMapper;
 
-    @Override
-    public String getSDKVersion() {
-        try (InputStream in =
-                     getClass().getClassLoader().getResourceAsStream("numaflow-java-sdk-version.properties")) {
-            if (in == null) {
-                log.warn("numaflow-java-sdk-version.properties not found in classpath");
-                return "";
-            }
-            Properties properties = new Properties();
-            properties.load(in);
-            return properties.getProperty("sdk.version", "");
-        } catch (IOException e) {
-            log.error("Error reading numaflow-java-sdk-version.properties", e);
-            return "";
-        }
+  @Override
+  public String getSDKVersion() {
+    try (InputStream in =
+        getClass().getClassLoader().getResourceAsStream("numaflow-java-sdk-version.properties")) {
+      if (in == null) {
+        log.warn("numaflow-java-sdk-version.properties not found in classpath");
+        return "";
+      }
+      Properties properties = new Properties();
+      properties.load(in);
+      return properties.getProperty("sdk.version", "");
+    } catch (IOException e) {
+      log.error("Error reading numaflow-java-sdk-version.properties", e);
+      return "";
     }
+  }
 
-    @Override
-    public void write(ServerInfo serverInfo, String filePath) throws Exception {
-        try (FileWriter fileWriter = new FileWriter(filePath);
-             BufferedWriter bufferedWriter = new BufferedWriter(fileWriter)) {
-            String jsonContent = objectMapper.writeValueAsString(serverInfo);
-            bufferedWriter.write(jsonContent);
-            bufferedWriter.write(INFO_EOF);
-        }
+  @Override
+  public void write(ServerInfo serverInfo, String filePath) throws Exception {
+    try (FileWriter fileWriter = new FileWriter(filePath);
+        BufferedWriter bufferedWriter = new BufferedWriter(fileWriter)) {
+      // Turn off AUTO_CLOSE_TARGET to prevent closing the underlying stream
+      // when the ObjectMapper is closed.
+      // We will let the FileWriter and BufferedWriter handle the closing.
+      objectMapper.configure(AUTO_CLOSE_TARGET, false);
+      objectMapper.writeValue(bufferedWriter, serverInfo);
+      bufferedWriter.write(INFO_EOF);
     }
+  }
 
-    @Override
-    public ServerInfo read(String filePath) throws Exception {
-        String content = Files.readString(Path.of(filePath));
-        String trimmedContent = verifyEOFAtEndAndTrim(content);
-        return objectMapper.readValue(trimmedContent, ServerInfo.class);
-    }
+  @Override
+  public ServerInfo read(String filePath) throws Exception {
+    String content = Files.readString(Path.of(filePath));
+    String trimmedContent = verifyEOFAtEndAndTrim(content);
+    return objectMapper.readValue(trimmedContent, ServerInfo.class);
+  }
 
-    private String verifyEOFAtEndAndTrim(String content) throws Exception {
-        int eofIndex = content.lastIndexOf(INFO_EOF);
-        if (eofIndex == -1) {
-            throw new Exception("EOF marker not found in the file content");
-        }
-        if (eofIndex != content.length() - INFO_EOF.length()) {
-            throw new Exception("EOF marker is not at the end of the file content");
-        }
-        return content.substring(0, eofIndex);
+  private String verifyEOFAtEndAndTrim(String content) throws Exception {
+    int eofIndex = content.lastIndexOf(INFO_EOF);
+    if (eofIndex == -1) {
+      throw new Exception("EOF marker not found in the file content");
     }
+    if (eofIndex != content.length() - INFO_EOF.length()) {
+      throw new Exception("EOF marker is not at the end of the file content");
+    }
+    return content.substring(0, eofIndex);
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/mapper/Constants.java
+++ b/src/main/java/io/numaproj/numaflow/mapper/Constants.java
@@ -1,19 +1,17 @@
 package io.numaproj.numaflow.mapper;
 
 class Constants {
-    public static final int DEFAULT_MESSAGE_SIZE = 1024 * 1024 * 64;
+  public static final int DEFAULT_MESSAGE_SIZE = 1024 * 1024 * 64;
+  public static final String DEFAULT_SOCKET_PATH = "/var/run/numaflow/map.sock";
+  public static final String DEFAULT_SERVER_INFO_FILE_PATH = "/var/run/numaflow/mapper-server-info";
+  public static final int DEFAULT_PORT = 50051;
+  public static final String DEFAULT_HOST = "localhost";
+  public static final String MAP_MODE_KEY = "MAP_MODE";
+  public static final String MAP_MODE = "unary-map";
+  public static final String EOF = "EOF";
 
-    public static final String DEFAULT_SOCKET_PATH = "/var/run/numaflow/map.sock";
-
-    public static final String DEFAULT_SERVER_INFO_FILE_PATH = "/var/run/numaflow/mapper-server-info";
-
-    public static final int DEFAULT_PORT = 50051;
-
-    public static final String DEFAULT_HOST = "localhost";
-
-    public static final String MAP_MODE_KEY = "MAP_MODE";
-
-    public static final String MAP_MODE = "unary-map";
-
-    public static final String EOF = "EOF";
+  // Private constructor to prevent instantiation
+  private Constants() {
+    throw new IllegalStateException("Utility class 'Constants' should not be instantiated");
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/mapper/Message.java
+++ b/src/main/java/io/numaproj/numaflow/mapper/Message.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 /** Message is used to wrap the data returned by Mapper. */
 @Getter(AccessLevel.PROTECTED)
-public class Message {
+public final class Message {
   private static final String[] DROP_TAGS = {"U+005C__DROP__"};
   private final String[] keys;
   private final byte[] value;

--- a/src/main/java/io/numaproj/numaflow/mapper/Message.java
+++ b/src/main/java/io/numaproj/numaflow/mapper/Message.java
@@ -1,10 +1,9 @@
 package io.numaproj.numaflow.mapper;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 
 /** Message is used to wrap the data returned by Mapper. */
-@Getter(AccessLevel.PROTECTED)
+@Getter
 public final class Message {
   private static final String[] DROP_TAGS = {"U+005C__DROP__"};
   private final String[] keys;

--- a/src/main/java/io/numaproj/numaflow/mapper/Message.java
+++ b/src/main/java/io/numaproj/numaflow/mapper/Message.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 /** Message is used to wrap the data returned by Mapper. */
 @Getter
-public final class Message {
+public class Message {
   private static final String[] DROP_TAGS = {"U+005C__DROP__"};
   private final String[] keys;
   private final byte[] value;

--- a/src/main/java/io/numaproj/numaflow/mapper/Message.java
+++ b/src/main/java/io/numaproj/numaflow/mapper/Message.java
@@ -6,8 +6,7 @@ import lombok.Getter;
 /** Message is used to wrap the data returned by Mapper. */
 @Getter(AccessLevel.PROTECTED)
 public class Message {
-  public static final String DROP = "U+005C__DROP__";
-
+  private static final String[] DROP_TAGS = {"U+005C__DROP__"};
   private final String[] keys;
   private final byte[] value;
   private final String[] tags;
@@ -50,6 +49,6 @@ public class Message {
    * @return returns the Message which will be dropped
    */
   public static Message toDrop() {
-    return new Message(new byte[0], null, new String[] {DROP});
+    return new Message(new byte[0], null, DROP_TAGS);
   }
 }

--- a/src/main/java/io/numaproj/numaflow/mapper/Message.java
+++ b/src/main/java/io/numaproj/numaflow/mapper/Message.java
@@ -19,9 +19,10 @@ public class Message {
    * @param tags message tags which will be used for conditional forwarding
    */
   public Message(byte[] value, String[] keys, String[] tags) {
-    this.keys = keys;
-    this.value = value;
-    this.tags = tags;
+    // defensive copy - once the Message is created, the caller should not be able to modify it.
+    this.keys = keys == null ? null : keys.clone();
+    this.value = value == null ? null : value.clone();
+    this.tags = tags == null ? null : tags.clone();
   }
 
   /**

--- a/src/main/java/io/numaproj/numaflow/mapper/Message.java
+++ b/src/main/java/io/numaproj/numaflow/mapper/Message.java
@@ -1,58 +1,55 @@
 package io.numaproj.numaflow.mapper;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 
-/**
- * Message is used to wrap the data returned by Mapper.
- */
-
-@Getter
+/** Message is used to wrap the data returned by Mapper. */
+@Getter(AccessLevel.PROTECTED)
 public class Message {
-    public static final String DROP = "U+005C__DROP__";
+  public static final String DROP = "U+005C__DROP__";
 
-    private final String[] keys;
-    private final byte[] value;
-    private final String[] tags;
+  private final String[] keys;
+  private final byte[] value;
+  private final String[] tags;
 
+  /**
+   * used to create Message with value, keys and tags(used for conditional forwarding)
+   *
+   * @param value message value
+   * @param keys message keys
+   * @param tags message tags which will be used for conditional forwarding
+   */
+  public Message(byte[] value, String[] keys, String[] tags) {
+    this.keys = keys;
+    this.value = value;
+    this.tags = tags;
+  }
 
-    /**
-     * used to create Message with value, keys and tags(used for conditional forwarding)
-     *
-     * @param value message value
-     * @param keys message keys
-     * @param tags message tags which will be used for conditional forwarding
-     */
-    public Message(byte[] value, String[] keys, String[] tags) {
-        this.keys = keys;
-        this.value = value;
-        this.tags = tags;
-    }
+  /**
+   * used to create Message with value.
+   *
+   * @param value message value
+   */
+  public Message(byte[] value) {
+    this(value, null, null);
+  }
 
-    /**
-     * used to create Message with value.
-     *
-     * @param value message value
-     */
-    public Message(byte[] value) {
-        this(value, null, null);
-    }
+  /**
+   * used to create Message with value and keys.
+   *
+   * @param value message value
+   * @param keys message keys
+   */
+  public Message(byte[] value, String[] keys) {
+    this(value, keys, null);
+  }
 
-    /**
-     * used to create Message with value and keys.
-     *
-     * @param value message value
-     * @param keys message keys
-     */
-    public Message(byte[] value, String[] keys) {
-        this(value, keys, null);
-    }
-
-    /**
-     * creates a Message which will be dropped
-     *
-     * @return returns the Message which will be dropped
-     */
-    public static Message toDrop() {
-        return new Message(new byte[0], null, new String[]{DROP});
-    }
+  /**
+   * creates a Message which will be dropped
+   *
+   * @return returns the Message which will be dropped
+   */
+  public static Message toDrop() {
+    return new Message(new byte[0], null, new String[] {DROP});
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/mapper/MessageList.java
+++ b/src/main/java/io/numaproj/numaflow/mapper/MessageList.java
@@ -1,17 +1,16 @@
 package io.numaproj.numaflow.mapper;
 
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Singular;
-import lombok.AccessLevel;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /** MessageList is used to return the list of Messages returned from Map functions. */
 @Getter(AccessLevel.PROTECTED)
 @Builder(builderMethodName = "newBuilder")
-public class MessageList {
+public final class MessageList {
 
   @Singular("addMessage")
   private List<Message> messages;

--- a/src/main/java/io/numaproj/numaflow/mapper/MessageList.java
+++ b/src/main/java/io/numaproj/numaflow/mapper/MessageList.java
@@ -2,13 +2,12 @@ package io.numaproj.numaflow.mapper;
 
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Singular;
 
 /** MessageList is used to return the list of Messages returned from Map functions. */
-@Getter(AccessLevel.PROTECTED)
+@Getter
 @Builder(builderMethodName = "newBuilder")
 public final class MessageList {
 

--- a/src/main/java/io/numaproj/numaflow/mapper/MessageList.java
+++ b/src/main/java/io/numaproj/numaflow/mapper/MessageList.java
@@ -3,39 +3,34 @@ package io.numaproj.numaflow.mapper;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Singular;
+import lombok.AccessLevel;
 
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * MessageList is used to return the list of Messages returned from Map functions.
- */
-
-@Getter
+/** MessageList is used to return the list of Messages returned from Map functions. */
+@Getter(AccessLevel.PROTECTED)
 @Builder(builderMethodName = "newBuilder")
 public class MessageList {
 
-    @Singular("addMessage")
-    private List<Message> messages;
+  @Singular("addMessage")
+  private List<Message> messages;
 
+  /** Builder to build MessageList */
+  public static class MessageListBuilder {
     /**
-     * Builder to build MessageList
+     * @param messages to append all the messages to MessageList
+     * @return returns the builder
      */
-    public static class MessageListBuilder {
-        /**
-         * @param messages to append all the messages to MessageList
-         *
-         * @return returns the builder
-         */
-        public MessageListBuilder addMessages(Iterable<Message> messages) {
-            if (this.messages == null) {
-                this.messages = new ArrayList<>();
-            }
+    public MessageListBuilder addMessages(Iterable<Message> messages) {
+      if (this.messages == null) {
+        this.messages = new ArrayList<>();
+      }
 
-            for (Message message : messages) {
-                this.messages.add(message);
-            }
-            return this;
-        }
+      for (Message message : messages) {
+        this.messages.add(message);
+      }
+      return this;
     }
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/mapper/MessageList.java
+++ b/src/main/java/io/numaproj/numaflow/mapper/MessageList.java
@@ -9,7 +9,7 @@ import lombok.Singular;
 /** MessageList is used to return the list of Messages returned from Map functions. */
 @Getter
 @Builder(builderMethodName = "newBuilder")
-public final class MessageList {
+public class MessageList {
 
   @Singular("addMessage")
   private List<Message> messages;

--- a/src/main/java/io/numaproj/numaflow/mapstreamer/Constants.java
+++ b/src/main/java/io/numaproj/numaflow/mapstreamer/Constants.java
@@ -1,17 +1,16 @@
 package io.numaproj.numaflow.mapstreamer;
 
 class Constants {
-    public static final int DEFAULT_MESSAGE_SIZE = 1024 * 1024 * 64;
+  public static final int DEFAULT_MESSAGE_SIZE = 1024 * 1024 * 64;
+  public static final String DEFAULT_SOCKET_PATH = "/var/run/numaflow/mapstream.sock";
+  public static final String DEFAULT_SERVER_INFO_FILE_PATH = "/var/run/numaflow/mapper-server-info";
+  public static final int DEFAULT_PORT = 50051;
+  public static final String DEFAULT_HOST = "localhost";
+  public static final String MAP_MODE_KEY = "MAP_MODE";
+  public static final String MAP_MODE = "stream-map";
 
-    public static final String DEFAULT_SOCKET_PATH = "/var/run/numaflow/mapstream.sock";
-
-    public static final String DEFAULT_SERVER_INFO_FILE_PATH = "/var/run/numaflow/mapper-server-info";
-
-    public static final int DEFAULT_PORT = 50051;
-
-    public static final String DEFAULT_HOST = "localhost";
-
-    public static final String MAP_MODE_KEY = "MAP_MODE";
-
-    public static final String MAP_MODE = "stream-map";
+  // Private constructor to prevent instantiation
+  private Constants() {
+    throw new IllegalStateException("Utility class 'Constants' should not be instantiated");
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/mapstreamer/Message.java
+++ b/src/main/java/io/numaproj/numaflow/mapstreamer/Message.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 /** Message is used to wrap the data returned by MapStreamer. */
 @Getter(AccessLevel.PROTECTED)
-public class Message {
+public final class Message {
   private static final String[] DROP_TAGS = {"U+005C__DROP__"};
   private final String[] keys;
   private final byte[] value;

--- a/src/main/java/io/numaproj/numaflow/mapstreamer/Message.java
+++ b/src/main/java/io/numaproj/numaflow/mapstreamer/Message.java
@@ -1,58 +1,55 @@
 package io.numaproj.numaflow.mapstreamer;
 
 import lombok.Getter;
+import lombok.AccessLevel;
 
-/**
- * Message is used to wrap the data returned by MapStreamer.
- */
-
-@Getter
+/** Message is used to wrap the data returned by MapStreamer. */
+@Getter(AccessLevel.PROTECTED)
 public class Message {
-    public static final String DROP = "U+005C__DROP__";
+  public static final String DROP = "U+005C__DROP__";
 
-    private final String[] keys;
-    private final byte[] value;
-    private final String[] tags;
+  private final String[] keys;
+  private final byte[] value;
+  private final String[] tags;
 
+  /**
+   * used to create Message with value, keys and tags(used for conditional forwarding)
+   *
+   * @param value message value
+   * @param keys message keys
+   * @param tags message tags which will be used for conditional forwarding
+   */
+  public Message(byte[] value, String[] keys, String[] tags) {
+    this.keys = keys;
+    this.value = value;
+    this.tags = tags;
+  }
 
-    /**
-     * used to create Message with value, keys and tags(used for conditional forwarding)
-     *
-     * @param value message value
-     * @param keys message keys
-     * @param tags message tags which will be used for conditional forwarding
-     */
-    public Message(byte[] value, String[] keys, String[] tags) {
-        this.keys = keys;
-        this.value = value;
-        this.tags = tags;
-    }
+  /**
+   * used to create Message with value.
+   *
+   * @param value message value
+   */
+  public Message(byte[] value) {
+    this(value, null, null);
+  }
 
-    /**
-     * used to create Message with value.
-     *
-     * @param value message value
-     */
-    public Message(byte[] value) {
-        this(value, null, null);
-    }
+  /**
+   * used to create Message with value and keys.
+   *
+   * @param value message value
+   * @param keys message keys
+   */
+  public Message(byte[] value, String[] keys) {
+    this(value, keys, null);
+  }
 
-    /**
-     * used to create Message with value and keys.
-     *
-     * @param value message value
-     * @param keys message keys
-     */
-    public Message(byte[] value, String[] keys) {
-        this(value, keys, null);
-    }
-
-    /**
-     * creates a Message which will be dropped
-     *
-     * @return returns the Message which will be dropped
-     */
-    public static Message toDrop() {
-        return new Message(new byte[0], null, new String[]{DROP});
-    }
+  /**
+   * creates a Message which will be dropped
+   *
+   * @return returns the Message which will be dropped
+   */
+  public static Message toDrop() {
+    return new Message(new byte[0], null, new String[] {DROP});
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/mapstreamer/Message.java
+++ b/src/main/java/io/numaproj/numaflow/mapstreamer/Message.java
@@ -1,13 +1,12 @@
 package io.numaproj.numaflow.mapstreamer;
 
-import lombok.Getter;
 import lombok.AccessLevel;
+import lombok.Getter;
 
 /** Message is used to wrap the data returned by MapStreamer. */
 @Getter(AccessLevel.PROTECTED)
 public class Message {
-  public static final String DROP = "U+005C__DROP__";
-
+  private static final String[] DROP_TAGS = {"U+005C__DROP__"};
   private final String[] keys;
   private final byte[] value;
   private final String[] tags;
@@ -50,6 +49,6 @@ public class Message {
    * @return returns the Message which will be dropped
    */
   public static Message toDrop() {
-    return new Message(new byte[0], null, new String[] {DROP});
+    return new Message(new byte[0], null, DROP_TAGS);
   }
 }

--- a/src/main/java/io/numaproj/numaflow/mapstreamer/Message.java
+++ b/src/main/java/io/numaproj/numaflow/mapstreamer/Message.java
@@ -1,10 +1,9 @@
 package io.numaproj.numaflow.mapstreamer;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 
 /** Message is used to wrap the data returned by MapStreamer. */
-@Getter(AccessLevel.PROTECTED)
+@Getter
 public final class Message {
   private static final String[] DROP_TAGS = {"U+005C__DROP__"};
   private final String[] keys;

--- a/src/main/java/io/numaproj/numaflow/mapstreamer/Message.java
+++ b/src/main/java/io/numaproj/numaflow/mapstreamer/Message.java
@@ -19,9 +19,10 @@ public class Message {
    * @param tags message tags which will be used for conditional forwarding
    */
   public Message(byte[] value, String[] keys, String[] tags) {
-    this.keys = keys;
-    this.value = value;
-    this.tags = tags;
+    // defensive copy - once the Message is created, the caller should not be able to modify it.
+    this.keys = keys == null ? null : keys.clone();
+    this.value = value == null ? null : value.clone();
+    this.tags = tags == null ? null : tags.clone();
   }
 
   /**

--- a/src/main/java/io/numaproj/numaflow/mapstreamer/Message.java
+++ b/src/main/java/io/numaproj/numaflow/mapstreamer/Message.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 /** Message is used to wrap the data returned by MapStreamer. */
 @Getter
-public final class Message {
+public class Message {
   private static final String[] DROP_TAGS = {"U+005C__DROP__"};
   private final String[] keys;
   private final byte[] value;

--- a/src/main/java/io/numaproj/numaflow/reducer/Constants.java
+++ b/src/main/java/io/numaproj/numaflow/reducer/Constants.java
@@ -1,19 +1,18 @@
 package io.numaproj.numaflow.reducer;
 
 class Constants {
-    public static final int DEFAULT_MESSAGE_SIZE = 1024 * 1024 * 64;
+  public static final int DEFAULT_MESSAGE_SIZE = 1024 * 1024 * 64;
+  public static final String DEFAULT_SOCKET_PATH = "/var/run/numaflow/reduce.sock";
+  public static final String DEFAULT_SERVER_INFO_FILE_PATH =
+      "/var/run/numaflow/reducer-server-info";
+  public static final int DEFAULT_PORT = 50051;
+  public static final String DEFAULT_HOST = "localhost";
+  public static final String EOF = "EOF";
+  public static final String SUCCESS = "SUCCESS";
+  public static final String DELIMITER = ":";
 
-    public static final String DEFAULT_SOCKET_PATH = "/var/run/numaflow/reduce.sock";
-
-    public static final String DEFAULT_SERVER_INFO_FILE_PATH = "/var/run/numaflow/reducer-server-info";
-
-    public static final int DEFAULT_PORT = 50051;
-
-    public static final String DEFAULT_HOST = "localhost";
-
-    public static final String EOF = "EOF";
-
-    public static final String SUCCESS = "SUCCESS";
-
-    public static final String DELIMITER = ":";
+  // Private constructor to prevent instantiation
+  private Constants() {
+    throw new IllegalStateException("Utility class 'Constants' should not be instantiated");
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/reducer/Message.java
+++ b/src/main/java/io/numaproj/numaflow/reducer/Message.java
@@ -1,58 +1,55 @@
 package io.numaproj.numaflow.reducer;
 
 import lombok.Getter;
+import lombok.AccessLevel;
 
-/**
- * Message is used to wrap the data returned by Reducer functions.
- */
-
-@Getter
+/** Message is used to wrap the data returned by Reducer functions. */
+@Getter(AccessLevel.PROTECTED)
 public class Message {
-    public static final String DROP = "U+005C__DROP__";
+  public static final String DROP = "U+005C__DROP__";
 
-    private final String[] keys;
-    private final byte[] value;
-    private final String[] tags;
+  private final String[] keys;
+  private final byte[] value;
+  private final String[] tags;
 
+  /**
+   * used to create Message with value, keys and tags(used for conditional forwarding)
+   *
+   * @param value message value
+   * @param keys message keys
+   * @param tags message tags which will be used for conditional forwarding
+   */
+  public Message(byte[] value, String[] keys, String[] tags) {
+    this.keys = keys;
+    this.value = value;
+    this.tags = tags;
+  }
 
-    /**
-     * used to create Message with value, keys and tags(used for conditional forwarding)
-     *
-     * @param value message value
-     * @param keys message keys
-     * @param tags message tags which will be used for conditional forwarding
-     */
-    public Message(byte[] value, String[] keys, String[] tags) {
-        this.keys = keys;
-        this.value = value;
-        this.tags = tags;
-    }
+  /**
+   * used to create Message with value.
+   *
+   * @param value message value
+   */
+  public Message(byte[] value) {
+    this(value, null, null);
+  }
 
-    /**
-     * used to create Message with value.
-     *
-     * @param value message value
-     */
-    public Message(byte[] value) {
-        this(value, null, null);
-    }
+  /**
+   * used to create Message with value and keys.
+   *
+   * @param value message value
+   * @param keys message keys
+   */
+  public Message(byte[] value, String[] keys) {
+    this(value, keys, null);
+  }
 
-    /**
-     * used to create Message with value and keys.
-     *
-     * @param value message value
-     * @param keys message keys
-     */
-    public Message(byte[] value, String[] keys) {
-        this(value, keys, null);
-    }
-
-    /**
-     * creates a Message which will be dropped
-     *
-     * @return returns the Message which will be dropped
-     */
-    public static Message toDrop() {
-        return new Message(new byte[0], null, new String[]{DROP});
-    }
+  /**
+   * creates a Message which will be dropped
+   *
+   * @return returns the Message which will be dropped
+   */
+  public static Message toDrop() {
+    return new Message(new byte[0], null, new String[] {DROP});
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/reducer/Message.java
+++ b/src/main/java/io/numaproj/numaflow/reducer/Message.java
@@ -1,13 +1,12 @@
 package io.numaproj.numaflow.reducer;
 
-import lombok.Getter;
 import lombok.AccessLevel;
+import lombok.Getter;
 
 /** Message is used to wrap the data returned by Reducer functions. */
 @Getter(AccessLevel.PROTECTED)
 public class Message {
-  public static final String DROP = "U+005C__DROP__";
-
+  private static final String[] DROP_TAGS = {"U+005C__DROP__"};
   private final String[] keys;
   private final byte[] value;
   private final String[] tags;
@@ -50,6 +49,6 @@ public class Message {
    * @return returns the Message which will be dropped
    */
   public static Message toDrop() {
-    return new Message(new byte[0], null, new String[] {DROP});
+    return new Message(new byte[0], null, DROP_TAGS);
   }
 }

--- a/src/main/java/io/numaproj/numaflow/reducer/Message.java
+++ b/src/main/java/io/numaproj/numaflow/reducer/Message.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 /** Message is used to wrap the data returned by Reducer functions. */
 @Getter(AccessLevel.PROTECTED)
-public class Message {
+public final class Message {
   private static final String[] DROP_TAGS = {"U+005C__DROP__"};
   private final String[] keys;
   private final byte[] value;

--- a/src/main/java/io/numaproj/numaflow/reducer/Message.java
+++ b/src/main/java/io/numaproj/numaflow/reducer/Message.java
@@ -19,9 +19,10 @@ public class Message {
    * @param tags message tags which will be used for conditional forwarding
    */
   public Message(byte[] value, String[] keys, String[] tags) {
-    this.keys = keys;
-    this.value = value;
-    this.tags = tags;
+    // defensive copy - once the Message is created, the caller should not be able to modify it.
+    this.keys = keys == null ? null : keys.clone();
+    this.value = value == null ? null : value.clone();
+    this.tags = tags == null ? null : tags.clone();
   }
 
   /**

--- a/src/main/java/io/numaproj/numaflow/reducer/Message.java
+++ b/src/main/java/io/numaproj/numaflow/reducer/Message.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 /** Message is used to wrap the data returned by Reducer functions. */
 @Getter
-public final class Message {
+public class Message {
   private static final String[] DROP_TAGS = {"U+005C__DROP__"};
   private final String[] keys;
   private final byte[] value;

--- a/src/main/java/io/numaproj/numaflow/reducer/Message.java
+++ b/src/main/java/io/numaproj/numaflow/reducer/Message.java
@@ -1,10 +1,9 @@
 package io.numaproj.numaflow.reducer;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 
 /** Message is used to wrap the data returned by Reducer functions. */
-@Getter(AccessLevel.PROTECTED)
+@Getter
 public final class Message {
   private static final String[] DROP_TAGS = {"U+005C__DROP__"};
   private final String[] keys;

--- a/src/main/java/io/numaproj/numaflow/reducer/MessageList.java
+++ b/src/main/java/io/numaproj/numaflow/reducer/MessageList.java
@@ -8,7 +8,7 @@ import lombok.Singular;
 
 @Getter
 @Builder(builderMethodName = "newBuilder")
-public final class MessageList {
+public class MessageList {
 
   @Singular("addMessage")
   private List<Message> messages;

--- a/src/main/java/io/numaproj/numaflow/reducer/MessageList.java
+++ b/src/main/java/io/numaproj/numaflow/reducer/MessageList.java
@@ -2,12 +2,11 @@ package io.numaproj.numaflow.reducer;
 
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Singular;
 
-@Getter(AccessLevel.PROTECTED)
+@Getter
 @Builder(builderMethodName = "newBuilder")
 public final class MessageList {
 

--- a/src/main/java/io/numaproj/numaflow/reducer/MessageList.java
+++ b/src/main/java/io/numaproj/numaflow/reducer/MessageList.java
@@ -1,16 +1,15 @@
 package io.numaproj.numaflow.reducer;
 
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Singular;
-import lombok.AccessLevel;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter(AccessLevel.PROTECTED)
 @Builder(builderMethodName = "newBuilder")
-public class MessageList {
+public final class MessageList {
 
   @Singular("addMessage")
   private List<Message> messages;

--- a/src/main/java/io/numaproj/numaflow/reducer/MessageList.java
+++ b/src/main/java/io/numaproj/numaflow/reducer/MessageList.java
@@ -3,35 +3,33 @@ package io.numaproj.numaflow.reducer;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Singular;
+import lombok.AccessLevel;
 
 import java.util.ArrayList;
 import java.util.List;
 
-@Getter
+@Getter(AccessLevel.PROTECTED)
 @Builder(builderMethodName = "newBuilder")
 public class MessageList {
 
-    @Singular("addMessage")
-    private List<Message> messages;
+  @Singular("addMessage")
+  private List<Message> messages;
 
+  /** Builder to build MessageList */
+  public static class MessageListBuilder {
     /**
-     * Builder to build MessageList
+     * @param messages to append all the messages to MessageList
+     * @return returns the builder
      */
-    public static class MessageListBuilder {
-        /**
-         * @param messages to append all the messages to MessageList
-         *
-         * @return returns the builder
-         */
-        public MessageListBuilder addMessages(Iterable<Message> messages) {
-            if (this.messages == null) {
-                this.messages = new ArrayList<>();
-            }
+    public MessageListBuilder addMessages(Iterable<Message> messages) {
+      if (this.messages == null) {
+        this.messages = new ArrayList<>();
+      }
 
-            for (Message message : messages) {
-                this.messages.add(message);
-            }
-            return this;
-        }
+      for (Message message : messages) {
+        this.messages.add(message);
+      }
+      return this;
     }
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/reducestreamer/Constants.java
+++ b/src/main/java/io/numaproj/numaflow/reducestreamer/Constants.java
@@ -1,19 +1,18 @@
 package io.numaproj.numaflow.reducestreamer;
 
 class Constants {
-    public static final int DEFAULT_MESSAGE_SIZE = 1024 * 1024 * 64;
+  public static final int DEFAULT_MESSAGE_SIZE = 1024 * 1024 * 64;
+  public static final String DEFAULT_SOCKET_PATH = "/var/run/numaflow/reducestream.sock";
+  public static final String DEFAULT_SERVER_INFO_FILE_PATH =
+      "/var/run/numaflow/reducestreamer-server-info";
+  public static final int DEFAULT_PORT = 50051;
+  public static final String DEFAULT_HOST = "localhost";
+  public static final String EOF = "EOF";
+  public static final String SUCCESS = "SUCCESS";
+  public static final String DELIMITER = ":";
 
-    public static final String DEFAULT_SOCKET_PATH = "/var/run/numaflow/reducestream.sock";
-
-    public static final String DEFAULT_SERVER_INFO_FILE_PATH = "/var/run/numaflow/reducestreamer-server-info";
-
-    public static final int DEFAULT_PORT = 50051;
-
-    public static final String DEFAULT_HOST = "localhost";
-
-    public static final String EOF = "EOF";
-
-    public static final String SUCCESS = "SUCCESS";
-
-    public static final String DELIMITER = ":";
+  // Private constructor to prevent instantiation
+  private Constants() {
+    throw new IllegalStateException("Utility class 'Constants' should not be instantiated");
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/reducestreamer/model/Message.java
+++ b/src/main/java/io/numaproj/numaflow/reducestreamer/model/Message.java
@@ -18,9 +18,10 @@ public class Message {
    * @param tags message tags which will be used for conditional forwarding
    */
   public Message(byte[] value, String[] keys, String[] tags) {
-    this.keys = keys;
-    this.value = value;
-    this.tags = tags;
+    // defensive copy - once the Message is created, the caller should not be able to modify it.
+    this.keys = keys == null ? null : keys.clone();
+    this.value = value == null ? null : value.clone();
+    this.tags = tags == null ? null : tags.clone();
   }
 
   /**

--- a/src/main/java/io/numaproj/numaflow/reducestreamer/model/Message.java
+++ b/src/main/java/io/numaproj/numaflow/reducestreamer/model/Message.java
@@ -2,55 +2,52 @@ package io.numaproj.numaflow.reducestreamer.model;
 
 import lombok.Getter;
 
-/**
- * Message is used to wrap the data returned by Reduce Streamer functions.
- */
+/** Message is used to wrap the data returned by Reduce Streamer functions. */
 @Getter
 public class Message {
-    public static final String DROP = "U+005C__DROP__";
-    private final String[] keys;
-    private final byte[] value;
-    private final String[] tags;
+  private static final String[] DROP_TAGS = {"U+005C__DROP__"};
+  private final String[] keys;
+  private final byte[] value;
+  private final String[] tags;
 
+  /**
+   * used to create Message with value, keys and tags(used for conditional forwarding)
+   *
+   * @param value message value
+   * @param keys message keys
+   * @param tags message tags which will be used for conditional forwarding
+   */
+  public Message(byte[] value, String[] keys, String[] tags) {
+    this.keys = keys;
+    this.value = value;
+    this.tags = tags;
+  }
 
-    /**
-     * used to create Message with value, keys and tags(used for conditional forwarding)
-     *
-     * @param value message value
-     * @param keys message keys
-     * @param tags message tags which will be used for conditional forwarding
-     */
-    public Message(byte[] value, String[] keys, String[] tags) {
-        this.keys = keys;
-        this.value = value;
-        this.tags = tags;
-    }
+  /**
+   * used to create Message with value.
+   *
+   * @param value message value
+   */
+  public Message(byte[] value) {
+    this(value, null, null);
+  }
 
-    /**
-     * used to create Message with value.
-     *
-     * @param value message value
-     */
-    public Message(byte[] value) {
-        this(value, null, null);
-    }
+  /**
+   * used to create Message with value and keys.
+   *
+   * @param value message value
+   * @param keys message keys
+   */
+  public Message(byte[] value, String[] keys) {
+    this(value, keys, null);
+  }
 
-    /**
-     * used to create Message with value and keys.
-     *
-     * @param value message value
-     * @param keys message keys
-     */
-    public Message(byte[] value, String[] keys) {
-        this(value, keys, null);
-    }
-
-    /**
-     * creates a Message which will be dropped
-     *
-     * @return returns the Message which will be dropped
-     */
-    public static Message toDrop() {
-        return new Message(new byte[0], null, new String[]{DROP});
-    }
+  /**
+   * creates a Message which will be dropped
+   *
+   * @return returns the Message which will be dropped
+   */
+  public static Message toDrop() {
+    return new Message(new byte[0], null, DROP_TAGS);
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/reducestreamer/model/Message.java
+++ b/src/main/java/io/numaproj/numaflow/reducestreamer/model/Message.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 /** Message is used to wrap the data returned by Reduce Streamer functions. */
 @Getter
-public final class Message {
+public class Message {
   private static final String[] DROP_TAGS = {"U+005C__DROP__"};
   private final String[] keys;
   private final byte[] value;

--- a/src/main/java/io/numaproj/numaflow/reducestreamer/model/Message.java
+++ b/src/main/java/io/numaproj/numaflow/reducestreamer/model/Message.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 /** Message is used to wrap the data returned by Reduce Streamer functions. */
 @Getter
-public class Message {
+public final class Message {
   private static final String[] DROP_TAGS = {"U+005C__DROP__"};
   private final String[] keys;
   private final byte[] value;

--- a/src/main/java/io/numaproj/numaflow/servingstore/Constants.java
+++ b/src/main/java/io/numaproj/numaflow/servingstore/Constants.java
@@ -1,13 +1,15 @@
 package io.numaproj.numaflow.servingstore;
 
 class Constants {
-    public static final int DEFAULT_MESSAGE_SIZE = 1024 * 1024 * 64;
+  public static final int DEFAULT_MESSAGE_SIZE = 1024 * 1024 * 64;
+  public static final String DEFAULT_SOCKET_PATH = "/var/run/numaflow/serving.sock";
+  public static final String DEFAULT_SERVER_INFO_FILE_PATH =
+      "/var/run/numaflow/serving-server-info";
+  public static final int DEFAULT_PORT = 50051;
+  public static final String DEFAULT_HOST = "localhost";
 
-    public static final String DEFAULT_SOCKET_PATH = "/var/run/numaflow/serving.sock";
-
-    public static final String DEFAULT_SERVER_INFO_FILE_PATH = "/var/run/numaflow/serving-server-info";
-
-    public static final int DEFAULT_PORT = 50051;
-
-    public static final String DEFAULT_HOST = "localhost";
+  // Private constructor to prevent instantiation
+  private Constants() {
+    throw new IllegalStateException("Utility class 'Constants' should not be instantiated");
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/sessionreducer/Constants.java
+++ b/src/main/java/io/numaproj/numaflow/sessionreducer/Constants.java
@@ -1,19 +1,18 @@
 package io.numaproj.numaflow.sessionreducer;
 
 class Constants {
-    public static final int DEFAULT_MESSAGE_SIZE = 1024 * 1024 * 64;
+  public static final int DEFAULT_MESSAGE_SIZE = 1024 * 1024 * 64;
+  public static final String DEFAULT_SOCKET_PATH = "/var/run/numaflow/sessionreduce.sock";
+  public static final String DEFAULT_SERVER_INFO_FILE_PATH =
+      "/var/run/numaflow/sessionreducer-server-info";
+  public static final int DEFAULT_PORT = 50051;
+  public static final String EOF = "EOF";
+  public static final String SUCCESS = "SUCCESS";
+  public static final String DEFAULT_HOST = "localhost";
+  public static final String DELIMITER = ":";
 
-    public static final String DEFAULT_SOCKET_PATH = "/var/run/numaflow/sessionreduce.sock";
-
-    public static final String DEFAULT_SERVER_INFO_FILE_PATH = "/var/run/numaflow/sessionreducer-server-info";
-
-    public static final int DEFAULT_PORT = 50051;
-
-    public static final String EOF = "EOF";
-
-    public static final String SUCCESS = "SUCCESS";
-
-    public static final String DEFAULT_HOST = "localhost";
-
-    public static final String DELIMITER = ":";
+  // Private constructor to prevent instantiation
+  private Constants() {
+    throw new IllegalStateException("Utility class 'Constants' should not be instantiated");
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/sessionreducer/UniqueIdGenerator.java
+++ b/src/main/java/io/numaproj/numaflow/sessionreducer/UniqueIdGenerator.java
@@ -5,25 +5,22 @@ import io.numaproj.numaflow.sessionreduce.v1.Sessionreduce;
 
 import java.time.Instant;
 
-/**
- * UniqueIdGenerator is a utility class to generate a unique id for a keyed session window.
- */
+/** UniqueIdGenerator is a utility class to generate a unique id for a keyed session window. */
 public class UniqueIdGenerator {
-    private UniqueIdGenerator() {
-        throw new AssertionError("utility class cannot be instantiated");
-    }
+  // private constructor to prevent instantiation
+  private UniqueIdGenerator() {
+    throw new AssertionError("utility class cannot be instantiated");
+  }
 
-    public static String getUniqueIdentifier(Sessionreduce.KeyedWindow keyedWindow) {
-        long startMillis = convertToEpochMilli(keyedWindow.getStart());
-        long endMillis = convertToEpochMilli(keyedWindow.getEnd());
-        return String.format(
-                "%d:%d:%s",
-                startMillis,
-                endMillis,
-                String.join(Constants.DELIMITER, keyedWindow.getKeysList()));
-    }
+  public static String getUniqueIdentifier(Sessionreduce.KeyedWindow keyedWindow) {
+    long startMillis = convertToEpochMilli(keyedWindow.getStart());
+    long endMillis = convertToEpochMilli(keyedWindow.getEnd());
+    return String.format(
+        "%d:%d:%s",
+        startMillis, endMillis, String.join(Constants.DELIMITER, keyedWindow.getKeysList()));
+  }
 
-    private static long convertToEpochMilli(Timestamp timestamp) {
-        return Instant.ofEpochSecond(timestamp.getSeconds(), timestamp.getNanos()).toEpochMilli();
-    }
+  private static long convertToEpochMilli(Timestamp timestamp) {
+    return Instant.ofEpochSecond(timestamp.getSeconds(), timestamp.getNanos()).toEpochMilli();
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/sessionreducer/model/Message.java
+++ b/src/main/java/io/numaproj/numaflow/sessionreducer/model/Message.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 /** Message is used to wrap the data returned by Session Reducer functions. */
 @Getter
-public class Message {
+public final class Message {
   private static final String[] DROP_TAGS = {"U+005C__DROP__"};
   private final String[] keys;
   private final byte[] value;

--- a/src/main/java/io/numaproj/numaflow/sessionreducer/model/Message.java
+++ b/src/main/java/io/numaproj/numaflow/sessionreducer/model/Message.java
@@ -18,9 +18,10 @@ public class Message {
    * @param tags message tags which will be used for conditional forwarding
    */
   public Message(byte[] value, String[] keys, String[] tags) {
-    this.keys = keys;
-    this.value = value;
-    this.tags = tags;
+    // defensive copy - once the Message is created, the caller should not be able to modify it.
+    this.keys = keys == null ? null : keys.clone();
+    this.value = value == null ? null : value.clone();
+    this.tags = tags == null ? null : tags.clone();
   }
 
   /**

--- a/src/main/java/io/numaproj/numaflow/sessionreducer/model/Message.java
+++ b/src/main/java/io/numaproj/numaflow/sessionreducer/model/Message.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 /** Message is used to wrap the data returned by Session Reducer functions. */
 @Getter
-public final class Message {
+public class Message {
   private static final String[] DROP_TAGS = {"U+005C__DROP__"};
   private final String[] keys;
   private final byte[] value;

--- a/src/main/java/io/numaproj/numaflow/sessionreducer/model/Message.java
+++ b/src/main/java/io/numaproj/numaflow/sessionreducer/model/Message.java
@@ -2,55 +2,52 @@ package io.numaproj.numaflow.sessionreducer.model;
 
 import lombok.Getter;
 
-/**
- * Message is used to wrap the data returned by Session Reducer functions.
- */
+/** Message is used to wrap the data returned by Session Reducer functions. */
 @Getter
 public class Message {
-    public static final String DROP = "U+005C__DROP__";
-    private final String[] keys;
-    private final byte[] value;
-    private final String[] tags;
+  private static final String[] DROP_TAGS = {"U+005C__DROP__"};
+  private final String[] keys;
+  private final byte[] value;
+  private final String[] tags;
 
+  /**
+   * used to create Message with value, keys and tags(used for conditional forwarding)
+   *
+   * @param value message value
+   * @param keys message keys
+   * @param tags message tags which will be used for conditional forwarding
+   */
+  public Message(byte[] value, String[] keys, String[] tags) {
+    this.keys = keys;
+    this.value = value;
+    this.tags = tags;
+  }
 
-    /**
-     * used to create Message with value, keys and tags(used for conditional forwarding)
-     *
-     * @param value message value
-     * @param keys message keys
-     * @param tags message tags which will be used for conditional forwarding
-     */
-    public Message(byte[] value, String[] keys, String[] tags) {
-        this.keys = keys;
-        this.value = value;
-        this.tags = tags;
-    }
+  /**
+   * used to create Message with value.
+   *
+   * @param value message value
+   */
+  public Message(byte[] value) {
+    this(value, null, null);
+  }
 
-    /**
-     * used to create Message with value.
-     *
-     * @param value message value
-     */
-    public Message(byte[] value) {
-        this(value, null, null);
-    }
+  /**
+   * used to create Message with value and keys.
+   *
+   * @param value message value
+   * @param keys message keys
+   */
+  public Message(byte[] value, String[] keys) {
+    this(value, keys, null);
+  }
 
-    /**
-     * used to create Message with value and keys.
-     *
-     * @param value message value
-     * @param keys message keys
-     */
-    public Message(byte[] value, String[] keys) {
-        this(value, keys, null);
-    }
-
-    /**
-     * creates a Message which will be dropped
-     *
-     * @return returns the Message which will be dropped
-     */
-    public static Message toDrop() {
-        return new Message(new byte[0], null, new String[]{DROP});
-    }
+  /**
+   * creates a Message which will be dropped
+   *
+   * @return returns the Message which will be dropped
+   */
+  public static Message toDrop() {
+    return new Message(new byte[0], null, DROP_TAGS);
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/shared/ExceptionUtils.java
+++ b/src/main/java/io/numaproj/numaflow/shared/ExceptionUtils.java
@@ -6,34 +6,39 @@ import java.util.Objects;
 
 public class ExceptionUtils {
 
-    /** 
-     * UD Container Type Environment Variable 
-    */
-    public static final String ENV_UD_CONTAINER_TYPE = "NUMAFLOW_UD_CONTAINER_TYPE";
-    public static final String CONTAINER_NAME = System.getenv(ENV_UD_CONTAINER_TYPE);
+  /** UD Container Type Environment Variable */
+  public static final String ENV_UD_CONTAINER_TYPE = "NUMAFLOW_UD_CONTAINER_TYPE";
 
-    /**
-     * Converts the stack trace of an exception into a String.
-     *
-     * @param t the exception to extract the stack trace from
-     *
-     * @return the stack trace as a String
-     */
-    public static String getStackTrace(Throwable t) {
-        if (t == null) {
-            return "No exception provided.";
-        }
-        StringWriter sw = new StringWriter();
-        t.printStackTrace(new PrintWriter(sw));
-        return sw.toString();
-    }
+  public static final String CONTAINER_NAME = System.getenv(ENV_UD_CONTAINER_TYPE);
 
-    /**
-     * Returns a formalized exception error string.
-     *
-     * @return the formalized exception error string
-     */
-    public static String getExceptionErrorString() {
-        return "UDF_EXECUTION_ERROR(" + Objects.requireNonNullElse(CONTAINER_NAME, "unknown-container") + ")";
+  // Private constructor to prevent instantiation
+  private ExceptionUtils() {
+    throw new IllegalStateException("Utility class 'ExceptionUtils' should not be instantiated");
+  }
+
+  /**
+   * Converts the stack trace of an exception into a String.
+   *
+   * @param t the exception to extract the stack trace from
+   * @return the stack trace as a String
+   */
+  public static String getStackTrace(Throwable t) {
+    if (t == null) {
+      return "No exception provided.";
     }
+    StringWriter sw = new StringWriter();
+    t.printStackTrace(new PrintWriter(sw));
+    return sw.toString();
+  }
+
+  /**
+   * Returns a formalized exception error string.
+   *
+   * @return the formalized exception error string
+   */
+  public static String getExceptionErrorString() {
+    return "UDF_EXECUTION_ERROR("
+        + Objects.requireNonNullElse(CONTAINER_NAME, "unknown-container")
+        + ")";
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/shared/GrpcServerUtils.java
+++ b/src/main/java/io/numaproj/numaflow/shared/GrpcServerUtils.java
@@ -1,5 +1,7 @@
 package io.numaproj.numaflow.shared;
 
+import static io.numaproj.numaflow.info.ServerInfo.MINIMUM_NUMAFLOW_VERSION;
+
 import io.grpc.Context;
 import io.grpc.Metadata;
 import io.netty.channel.EventLoopGroup;
@@ -14,108 +16,96 @@ import io.numaproj.numaflow.info.Language;
 import io.numaproj.numaflow.info.Protocol;
 import io.numaproj.numaflow.info.ServerInfo;
 import io.numaproj.numaflow.info.ServerInfoAccessor;
-import lombok.extern.slf4j.Slf4j;
-
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 
-import static io.numaproj.numaflow.info.ServerInfo.MINIMUM_NUMAFLOW_VERSION;
-
-/**
- * GrpcServerUtils is the utility class for netty server channel.
- */
+/** GrpcServerUtils is the utility class for netty server channel. */
 @Slf4j
 public class GrpcServerUtils {
 
-    public static final String WIN_START_KEY = "x-numaflow-win-start-time";
+  public static final String WIN_START_KEY = "x-numaflow-win-start-time";
+  public static final String WIN_END_KEY = "x-numaflow-win-end-time";
+  public static final Context.Key<String> WINDOW_START_TIME =
+      Context.keyWithDefault(WIN_START_KEY, "");
+  public static final Context.Key<String> WINDOW_END_TIME = Context.keyWithDefault(WIN_END_KEY, "");
+  public static final Metadata.Key<String> DATUM_METADATA_WIN_START =
+      Metadata.Key.of(WIN_START_KEY, Metadata.ASCII_STRING_MARSHALLER);
+  public static final Metadata.Key<String> DATUM_METADATA_WIN_END =
+      Metadata.Key.of(WIN_END_KEY, Metadata.ASCII_STRING_MARSHALLER);
 
-    public static final String WIN_END_KEY = "x-numaflow-win-end-time";
+  // private constructor to prevent instantiation
+  private GrpcServerUtils() {
+    throw new IllegalArgumentException(
+        "Utility class 'GrpcServerUtils' should not be instantiated");
+  }
 
-    public static final Context.Key<String> WINDOW_START_TIME = Context.keyWithDefault(
-            WIN_START_KEY,
-            "");
+  /*
+   * Get the server socket channel class based on the availability of epoll and kqueue.
+   */
+  public static Class<? extends ServerChannel> getChannelTypeClass() {
+    if (KQueue.isAvailable()) {
+      return KQueueServerDomainSocketChannel.class;
+    }
+    return EpollServerDomainSocketChannel.class;
+  }
 
-    public static final Context.Key<String> WINDOW_END_TIME = Context.keyWithDefault(
-            WIN_END_KEY,
-            "");
+  /*
+   * Get the event loop group based on the availability of epoll and kqueue.
+   */
+  public static EventLoopGroup createEventLoopGroup(int threads, String name) {
+    if (KQueue.isAvailable()) {
+      return new KQueueEventLoopGroup(threads, ThreadUtils.INSTANCE.newThreadFactory(name));
+    }
+    return new EpollEventLoopGroup(threads, ThreadUtils.INSTANCE.newThreadFactory(name));
+  }
 
-    public static final Metadata.Key<String> DATUM_METADATA_WIN_START = Metadata.Key.of(
-            WIN_START_KEY,
-            Metadata.ASCII_STRING_MARSHALLER);
+  public static void writeServerInfo(
+      ServerInfoAccessor serverInfoAccessor,
+      String socketPath,
+      String infoFilePath,
+      ContainerType containerType)
+      throws Exception {
+    writeServerInfo(serverInfoAccessor, socketPath, infoFilePath, containerType, new HashMap<>());
+  }
 
-
-    public static final Metadata.Key<String> DATUM_METADATA_WIN_END = Metadata.Key.of(
-            WIN_END_KEY,
-            Metadata.ASCII_STRING_MARSHALLER);
-
-    /*
-     * Get the server socket channel class based on the availability of epoll and kqueue.
-     */
-    public static Class<? extends ServerChannel> getChannelTypeClass() {
-        if (KQueue.isAvailable()) {
-            return KQueueServerDomainSocketChannel.class;
-        }
-        return EpollServerDomainSocketChannel.class;
+  public static void writeServerInfo(
+      ServerInfoAccessor serverInfoAccessor,
+      String socketPath,
+      String infoFilePath,
+      ContainerType containerType,
+      Map<String, String> metaData)
+      throws Exception {
+    // cleanup socket path if it exists (unit test builder doesn't use one)
+    if (socketPath != null) {
+      Path path = Paths.get(socketPath);
+      Files.deleteIfExists(path);
+      if (Files.exists(path)) {
+        log.error("Failed to clean up socket path {}. Exiting", socketPath);
+      }
     }
 
-    /*
-     * Get the event loop group based on the availability of epoll and kqueue.
-     */
-    public static EventLoopGroup createEventLoopGroup(int threads, String name) {
-        if (KQueue.isAvailable()) {
-            return new KQueueEventLoopGroup(threads, ThreadUtils.INSTANCE.newThreadFactory(name));
-        }
-        return new EpollEventLoopGroup(threads, ThreadUtils.INSTANCE.newThreadFactory(name));
+    // server info file can be null if the Grpc server is used for local component testing
+    // write server info to file if file path is not null
+    if (infoFilePath == null) {
+      return;
     }
 
-    public static void writeServerInfo(
-            ServerInfoAccessor serverInfoAccessor,
-            String socketPath,
-            String infoFilePath,
-            ContainerType containerType) throws Exception {
-        writeServerInfo(
-                serverInfoAccessor,
-                socketPath,
-                infoFilePath,
-                containerType,
-                new HashMap<>());
+    if (metaData == null) {
+      metaData = new HashMap<>();
     }
 
-    public static void writeServerInfo(
-            ServerInfoAccessor serverInfoAccessor,
-            String socketPath,
-            String infoFilePath,
-            ContainerType containerType,
-            Map<String, String> metaData) throws Exception {
-        // cleanup socket path if it exists (unit test builder doesn't use one)
-        if (socketPath != null) {
-            Path path = Paths.get(socketPath);
-            Files.deleteIfExists(path);
-            if (Files.exists(path)) {
-                log.error("Failed to clean up socket path {}. Exiting", socketPath);
-            }
-        }
-
-        // server info file can be null if the Grpc server is used for local component testing
-        // write server info to file if file path is not null
-        if (infoFilePath == null) {
-            return;
-        }
-
-        if (metaData == null) {
-            metaData = new HashMap<>();
-        }
-
-        ServerInfo serverInfo = new ServerInfo(
-                Protocol.UDS_PROTOCOL,
-                Language.JAVA,
-                MINIMUM_NUMAFLOW_VERSION.get(containerType),
-                serverInfoAccessor.getSDKVersion(),
-                metaData);
-        log.info("Writing server info {} to {}", serverInfo, infoFilePath);
-        serverInfoAccessor.write(serverInfo, infoFilePath);
-    }
+    ServerInfo serverInfo =
+        new ServerInfo(
+            Protocol.UDS_PROTOCOL,
+            Language.JAVA,
+            MINIMUM_NUMAFLOW_VERSION.get(containerType),
+            serverInfoAccessor.getSDKVersion(),
+            metaData);
+    log.info("Writing server info {} to {}", serverInfo, infoFilePath);
+    serverInfoAccessor.write(serverInfo, infoFilePath);
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/sideinput/Constants.java
+++ b/src/main/java/io/numaproj/numaflow/sideinput/Constants.java
@@ -1,11 +1,15 @@
 package io.numaproj.numaflow.sideinput;
 
-public class Constants {
-    public static final String SIDE_INPUT_DIR = "/var/numaflow/side-inputs";
-    static final String DEFAULT_SOCKET_PATH = "/var/run/numaflow/sideinput.sock";
+class Constants {
+  public static final String SIDE_INPUT_DIR = "/var/numaflow/side-inputs";
+  static final String DEFAULT_SOCKET_PATH = "/var/run/numaflow/sideinput.sock";
+  static final String DEFAULT_SERVER_INFO_FILE_PATH = "/var/run/numaflow/sideinput-server-info";
+  static final String DEFAULT_HOST = "localhost";
+  static int DEFAULT_MESSAGE_SIZE = 1024 * 1024 * 64;
+  static int DEFAULT_PORT = 50051;
 
-    static final String DEFAULT_SERVER_INFO_FILE_PATH = "/var/run/numaflow/sideinput-server-info";
-    static final String DEFAULT_HOST = "localhost";
-    static int DEFAULT_MESSAGE_SIZE = 1024 * 1024 * 64;
-    static int DEFAULT_PORT = 50051;
+  // Private constructor to prevent instantiation
+  private Constants() {
+    throw new IllegalStateException("Utility class 'Constants' should not be instantiated");
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/sideinput/Message.java
+++ b/src/main/java/io/numaproj/numaflow/sideinput/Message.java
@@ -5,7 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /** Message is used to wrap the data returned by Side Input Retriever. */
-@Getter(AccessLevel.PROTECTED)
+@Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public final class Message {
   private final byte[] value;

--- a/src/main/java/io/numaproj/numaflow/sideinput/Message.java
+++ b/src/main/java/io/numaproj/numaflow/sideinput/Message.java
@@ -4,35 +4,31 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-/**
- * Message is used to wrap the data returned by Side Input Retriever.
- */
-
-@Getter
+/** Message is used to wrap the data returned by Side Input Retriever. */
+@Getter(AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Message {
-    private final byte[] value;
-    private final boolean noBroadcast;
+  private final byte[] value;
+  private final boolean noBroadcast;
 
-    /**
-     * createBroadcastMessage creates a new Message with the given value
-     * This is used to broadcast the message to other side input vertices.
-     *
-     * @param value message value
-     *
-     * @return returns the Message with noBroadcast flag set to false
-     */
-    public static Message createBroadcastMessage(byte[] value) {
-        return new Message(value, false);
-    }
+  /**
+   * createBroadcastMessage creates a new Message with the given value This is used to broadcast the
+   * message to other side input vertices.
+   *
+   * @param value message value
+   * @return returns the Message with noBroadcast flag set to false
+   */
+  public static Message createBroadcastMessage(byte[] value) {
+    return new Message(value, false);
+  }
 
-    /**
-     * createNoBroadcastMessage creates a new Message with noBroadcast flag set to true
-     * This is used to drop the message and not to broadcast it to other side input vertices.
-     *
-     * @return returns the Message with noBroadcast flag set to true
-     */
-    public static Message createNoBroadcastMessage() {
-        return new Message(new byte[0], true);
-    }
+  /**
+   * createNoBroadcastMessage creates a new Message with noBroadcast flag set to true This is used
+   * to drop the message and not to broadcast it to other side input vertices.
+   *
+   * @return returns the Message with noBroadcast flag set to true
+   */
+  public static Message createNoBroadcastMessage() {
+    return new Message(new byte[0], true);
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/sideinput/Message.java
+++ b/src/main/java/io/numaproj/numaflow/sideinput/Message.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 /** Message is used to wrap the data returned by Side Input Retriever. */
 @Getter
-public final class Message {
+public class Message {
   private final byte[] value;
   private final boolean noBroadcast;
 

--- a/src/main/java/io/numaproj/numaflow/sideinput/Message.java
+++ b/src/main/java/io/numaproj/numaflow/sideinput/Message.java
@@ -1,15 +1,19 @@
 package io.numaproj.numaflow.sideinput;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /** Message is used to wrap the data returned by Side Input Retriever. */
 @Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public final class Message {
   private final byte[] value;
   private final boolean noBroadcast;
+
+  /** used to create Message with value and noBroadcast flag. */
+  private Message(byte[] value, boolean noBroadcast) {
+    // defensive copy - once the Message is created, the caller should not be able to modify it.
+    this.value = value == null ? null : value.clone();
+    this.noBroadcast = noBroadcast;
+  }
 
   /**
    * createBroadcastMessage creates a new Message with the given value This is used to broadcast the

--- a/src/main/java/io/numaproj/numaflow/sideinput/Message.java
+++ b/src/main/java/io/numaproj/numaflow/sideinput/Message.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 /** Message is used to wrap the data returned by Side Input Retriever. */
 @Getter(AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class Message {
+public final class Message {
   private final byte[] value;
   private final boolean noBroadcast;
 

--- a/src/main/java/io/numaproj/numaflow/sinker/Constants.java
+++ b/src/main/java/io/numaproj/numaflow/sinker/Constants.java
@@ -1,21 +1,19 @@
 package io.numaproj.numaflow.sinker;
 
 class Constants {
-    public static final String DEFAULT_SOCKET_PATH = "/var/run/numaflow/sink.sock";
+  public static final String DEFAULT_SOCKET_PATH = "/var/run/numaflow/sink.sock";
+  public static final String DEFAULT_FB_SINK_SOCKET_PATH = "/var/run/numaflow/fb-sink.sock";
+  public static final String DEFAULT_SERVER_INFO_FILE_PATH = "/var/run/numaflow/sinker-server-info";
+  public static final String DEFAULT_FB_SERVER_INFO_FILE_PATH =
+      "/var/run/numaflow/fb-sinker-server-info";
+  public static final int DEFAULT_MESSAGE_SIZE = 1024 * 1024 * 64;
+  public static final int DEFAULT_PORT = 50051;
+  public static final String DEFAULT_HOST = "localhost";
+  public static final String ENV_UD_CONTAINER_TYPE = "NUMAFLOW_UD_CONTAINER_TYPE";
+  public static final String UD_CONTAINER_FALLBACK_SINK = "fb-udsink";
 
-    public static final String DEFAULT_FB_SINK_SOCKET_PATH = "/var/run/numaflow/fb-sink.sock";
-
-    public static final String DEFAULT_SERVER_INFO_FILE_PATH = "/var/run/numaflow/sinker-server-info";
-
-    public static final String DEFAULT_FB_SERVER_INFO_FILE_PATH = "/var/run/numaflow/fb-sinker-server-info";
-
-    public static final int DEFAULT_MESSAGE_SIZE = 1024 * 1024 * 64;
-
-    public static final int DEFAULT_PORT = 50051;
-
-    public static final String DEFAULT_HOST = "localhost";
-
-    public static final String ENV_UD_CONTAINER_TYPE = "NUMAFLOW_UD_CONTAINER_TYPE";
-
-    public static final String UD_CONTAINER_FALLBACK_SINK = "fb-udsink";
+  // Private constructor to prevent instantiation
+  private Constants() {
+    throw new IllegalStateException("Utility class 'Constants' should not be instantiated");
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/sinker/Response.java
+++ b/src/main/java/io/numaproj/numaflow/sinker/Response.java
@@ -4,7 +4,6 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-
 /**
  * Response is used to send response from the user defined sinker. It contains the id of the
  * message, success status, an optional error message and a fallback status. Various static factory
@@ -12,7 +11,7 @@ import lombok.Getter;
  */
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class Response {
+public final class Response {
     private final String id;
     private final boolean success;
     private final String err;

--- a/src/main/java/io/numaproj/numaflow/sinker/Response.java
+++ b/src/main/java/io/numaproj/numaflow/sinker/Response.java
@@ -11,45 +11,41 @@ import lombok.Getter;
  */
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public final class Response {
-    private final String id;
-    private final boolean success;
-    private final String err;
-    private final boolean fallback;
+public class Response {
+  private final String id;
+  private final boolean success;
+  private final String err;
+  private final boolean fallback;
 
-    /**
-     * Static method to create response for successful message processing.
-     *
-     * @param id id of the message
-     *
-     * @return Response object with success status
-     */
-    public static Response responseOK(String id) {
-        return new Response(id, true, null, false);
-    }
+  /**
+   * Static method to create response for successful message processing.
+   *
+   * @param id id of the message
+   * @return Response object with success status
+   */
+  public static Response responseOK(String id) {
+    return new Response(id, true, null, false);
+  }
 
-    /**
-     * Static method to create response for failed message processing.
-     *
-     * @param id id of the message
-     * @param errMsg error message
-     *
-     * @return Response object with failure status and error message
-     */
-    public static Response responseFailure(String id, String errMsg) {
-        return new Response(id, false, errMsg, false);
-    }
+  /**
+   * Static method to create response for failed message processing.
+   *
+   * @param id id of the message
+   * @param errMsg error message
+   * @return Response object with failure status and error message
+   */
+  public static Response responseFailure(String id, String errMsg) {
+    return new Response(id, false, errMsg, false);
+  }
 
-
-    /**
-     * Static method to create response for fallback message.
-     * This indicates that the message should be sent to the fallback sink.
-     *
-     * @param id id of the message
-     *
-     * @return Response object with fallback status
-     */
-    public static Response responseFallback(String id) {
-        return new Response(id, false, null, true);
-    }
+  /**
+   * Static method to create response for fallback message. This indicates that the message should
+   * be sent to the fallback sink.
+   *
+   * @param id id of the message
+   * @return Response object with fallback status
+   */
+  public static Response responseFallback(String id) {
+    return new Response(id, false, null, true);
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/sinker/Response.java
+++ b/src/main/java/io/numaproj/numaflow/sinker/Response.java
@@ -4,19 +4,19 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+
 /**
- * Response is used to send response from the user defined sinker.
- * It contains the id of the message, success status and error message.
- * If the message is processed successfully, responseOK method can be used to create the response.
- * If the message is not processed successfully, responseFailure method can be used to create the response.
+ * Response is used to send response from the user defined sinker. It contains the id of the
+ * message, success status, an optional error message and a fallback status. Various static factory
+ * methods are available to create a Response instance based on the processing outcome.
  */
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Response {
     private final String id;
-    private final Boolean success;
+    private final boolean success;
     private final String err;
-    private final Boolean fallback;
+    private final boolean fallback;
 
     /**
      * Static method to create response for successful message processing.

--- a/src/main/java/io/numaproj/numaflow/sinker/Service.java
+++ b/src/main/java/io/numaproj/numaflow/sinker/Service.java
@@ -139,8 +139,8 @@ class Service extends SinkGrpc.SinkImplBase {
     }
 
     private SinkOuterClass.SinkResponse.Result buildResult(Response response) {
-        SinkOuterClass.Status status = response.getFallback() ? SinkOuterClass.Status.FALLBACK
-                : response.getSuccess() ? SinkOuterClass.Status.SUCCESS : SinkOuterClass.Status.FAILURE;
+        SinkOuterClass.Status status = response.isFallback() ? SinkOuterClass.Status.FALLBACK
+                : response.isSuccess() ? SinkOuterClass.Status.SUCCESS : SinkOuterClass.Status.FAILURE;
         return SinkOuterClass.SinkResponse.Result.newBuilder()
                 .setId(response.getId() == null ? "" : response.getId())
                 .setErrMsg(response.getErr() == null ? "" : response.getErr())

--- a/src/main/java/io/numaproj/numaflow/sourcer/Constants.java
+++ b/src/main/java/io/numaproj/numaflow/sourcer/Constants.java
@@ -1,13 +1,15 @@
 package io.numaproj.numaflow.sourcer;
 
 class Constants {
-    public static final String DEFAULT_SOCKET_PATH = "/var/run/numaflow/source.sock";
+  public static final String DEFAULT_SOCKET_PATH = "/var/run/numaflow/source.sock";
+  public static final String DEFAULT_SERVER_INFO_FILE_PATH =
+      "/var/run/numaflow/sourcer-server-info";
+  public static final int DEFAULT_MESSAGE_SIZE = 1024 * 1024 * 64;
+  public static final int DEFAULT_PORT = 50051;
+  public static final String DEFAULT_HOST = "localhost";
 
-    public static final String DEFAULT_SERVER_INFO_FILE_PATH = "/var/run/numaflow/sourcer-server-info";
-
-    public static final int DEFAULT_MESSAGE_SIZE = 1024 * 1024 * 64;
-
-    public static final int DEFAULT_PORT = 50051;
-
-    public static final String DEFAULT_HOST = "localhost";
+  // Private constructor to prevent instantiation
+  private Constants() {
+    throw new IllegalStateException("Utility class 'Constants' should not be instantiated");
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/sourcer/Message.java
+++ b/src/main/java/io/numaproj/numaflow/sourcer/Message.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 /** Message is used to wrap the data returned by Sourcer. */
 @Getter
-public final class Message {
+public class Message {
 
   private final String[] keys;
   private final byte[] value;

--- a/src/main/java/io/numaproj/numaflow/sourcer/Message.java
+++ b/src/main/java/io/numaproj/numaflow/sourcer/Message.java
@@ -2,11 +2,10 @@ package io.numaproj.numaflow.sourcer;
 
 import java.time.Instant;
 import java.util.Map;
-import lombok.AccessLevel;
 import lombok.Getter;
 
 /** Message is used to wrap the data returned by Sourcer. */
-@Getter(AccessLevel.PROTECTED)
+@Getter
 public final class Message {
 
   private final String[] keys;

--- a/src/main/java/io/numaproj/numaflow/sourcer/Message.java
+++ b/src/main/java/io/numaproj/numaflow/sourcer/Message.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 
 /** Message is used to wrap the data returned by Sourcer. */
 @Getter(AccessLevel.PROTECTED)
-public class Message {
+public final class Message {
 
   private final String[] keys;
   private final byte[] value;

--- a/src/main/java/io/numaproj/numaflow/sourcer/Message.java
+++ b/src/main/java/io/numaproj/numaflow/sourcer/Message.java
@@ -61,10 +61,12 @@ public class Message {
    */
   public Message(
       byte[] value, Offset offset, Instant eventTime, String[] keys, Map<String, String> headers) {
-    this.value = value;
-    this.offset = offset;
+    // defensive copy - once the Message is created, the caller should not be able to modify it.
+    this.keys = keys == null ? null : keys.clone();
+    this.value = value == null ? null : value.clone();
+    this.headers = headers == null ? null : Map.copyOf(headers);
+    this.offset = offset == null ? null : new Offset(offset.getValue(), offset.getPartitionId());
+    // The Instant class in Java is already immutable.
     this.eventTime = eventTime;
-    this.keys = keys;
-    this.headers = headers;
   }
 }

--- a/src/main/java/io/numaproj/numaflow/sourcer/Message.java
+++ b/src/main/java/io/numaproj/numaflow/sourcer/Message.java
@@ -1,77 +1,70 @@
 package io.numaproj.numaflow.sourcer;
 
-import lombok.Getter;
-
 import java.time.Instant;
 import java.util.Map;
+import lombok.AccessLevel;
+import lombok.Getter;
 
-/**
- * Message is used to wrap the data returned by Sourcer.
- */
-
-@Getter
+/** Message is used to wrap the data returned by Sourcer. */
+@Getter(AccessLevel.PROTECTED)
 public class Message {
 
-    private final String[] keys;
-    private final byte[] value;
-    private final Offset offset;
-    private final Instant eventTime;
-    private final Map<String, String> headers;
+  private final String[] keys;
+  private final byte[] value;
+  private final Offset offset;
+  private final Instant eventTime;
+  private final Map<String, String> headers;
 
-    /**
-     * used to create Message with value, offset and eventTime.
-     *
-     * @param value message value
-     * @param offset message offset
-     * @param eventTime message eventTime
-     */
-    public Message(byte[] value, Offset offset, Instant eventTime) {
-        this(value, offset, eventTime, null, null);
-    }
+  /**
+   * used to create Message with value, offset and eventTime.
+   *
+   * @param value message value
+   * @param offset message offset
+   * @param eventTime message eventTime
+   */
+  public Message(byte[] value, Offset offset, Instant eventTime) {
+    this(value, offset, eventTime, null, null);
+  }
 
-    /**
-     * used to create Message with value, offset, eventTime and keys.
-     *
-     * @param value message value
-     * @param offset message offset
-     * @param eventTime message eventTime
-     * @param keys message keys
-     */
-    public Message(byte[] value, Offset offset, Instant eventTime, String[] keys) {
-        this(value, offset, eventTime, keys, null);
-    }
+  /**
+   * used to create Message with value, offset, eventTime and keys.
+   *
+   * @param value message value
+   * @param offset message offset
+   * @param eventTime message eventTime
+   * @param keys message keys
+   */
+  public Message(byte[] value, Offset offset, Instant eventTime, String[] keys) {
+    this(value, offset, eventTime, keys, null);
+  }
 
-    /**
-     * used to create Message with value, offset, eventTime and headers.
-     *
-     * @param value message value
-     * @param offset message offset
-     * @param eventTime message eventTime
-     * @param headers message headers
-     */
-    public Message(byte[] value, Offset offset, Instant eventTime, Map<String, String> headers) {
-        this(value, offset, eventTime, null, headers);
-    }
+  /**
+   * used to create Message with value, offset, eventTime and headers.
+   *
+   * @param value message value
+   * @param offset message offset
+   * @param eventTime message eventTime
+   * @param headers message headers
+   */
+  public Message(byte[] value, Offset offset, Instant eventTime, Map<String, String> headers) {
+    this(value, offset, eventTime, null, headers);
+  }
 
-    /**
-     * used to create Message with value, offset, eventTime, keys and headers.
-     *
-     * @param value message value
-     * @param offset message offset
-     * @param eventTime message eventTime
-     * @param keys message keys
-     * @param headers message headers
-     */
-    public Message(
-            byte[] value,
-            Offset offset,
-            Instant eventTime,
-            String[] keys,
-            Map<String, String> headers) {
-        this.value = value;
-        this.offset = offset;
-        this.eventTime = eventTime;
-        this.keys = keys;
-        this.headers = headers;
-    }
+  /**
+   * used to create Message with value, offset, eventTime, keys and headers.
+   *
+   * @param value message value
+   * @param offset message offset
+   * @param eventTime message eventTime
+   * @param keys message keys
+   * @param headers message headers
+   */
+  public Message(
+      byte[] value, Offset offset, Instant eventTime, String[] keys, Map<String, String> headers) {
+    this.value = value;
+    this.offset = offset;
+    this.eventTime = eventTime;
+    this.keys = keys;
+    this.headers = headers;
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/sourcetransformer/Constants.java
+++ b/src/main/java/io/numaproj/numaflow/sourcetransformer/Constants.java
@@ -1,15 +1,16 @@
 package io.numaproj.numaflow.sourcetransformer;
 
 class Constants {
-    public static final String DEFAULT_SOCKET_PATH = "/var/run/numaflow/sourcetransform.sock";
+  public static final String DEFAULT_SOCKET_PATH = "/var/run/numaflow/sourcetransform.sock";
+  public static final String DEFAULT_SERVER_INFO_FILE_PATH =
+      "/var/run/numaflow/sourcetransformer-server-info";
+  public static final String DEFAULT_HOST = "localhost";
+  public static final String EOF = "EOF";
+  public static int DEFAULT_MESSAGE_SIZE = 1024 * 1024 * 64;
+  public static int DEFAULT_PORT = 50051;
 
-    public static final String DEFAULT_SERVER_INFO_FILE_PATH = "/var/run/numaflow/sourcetransformer-server-info";
-
-    public static final String DEFAULT_HOST = "localhost";
-
-    public static int DEFAULT_MESSAGE_SIZE = 1024 * 1024 * 64;
-
-    public static int DEFAULT_PORT = 50051;
-    
-    public static final String EOF = "EOF";
+  // Private constructor to prevent instantiation
+  private Constants() {
+    throw new IllegalStateException("Utility class 'Constants' should not be instantiated");
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/sourcetransformer/Message.java
+++ b/src/main/java/io/numaproj/numaflow/sourcetransformer/Message.java
@@ -22,9 +22,11 @@ public class Message {
    * @param tags message tags which will be used for conditional forwarding
    */
   public Message(byte[] value, Instant eventTime, String[] keys, String[] tags) {
-    this.keys = keys;
-    this.value = value;
-    this.tags = tags;
+    // defensive copy - once the Message is created, the caller should not be able to modify it.
+    this.keys = keys == null ? null : keys.clone();
+    this.value = value == null ? null : value.clone();
+    this.tags = tags == null ? null : tags.clone();
+    // The Instant class in Java is already immutable.
     this.eventTime = eventTime;
   }
 

--- a/src/main/java/io/numaproj/numaflow/sourcetransformer/Message.java
+++ b/src/main/java/io/numaproj/numaflow/sourcetransformer/Message.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 /** Message is used to wrap the data return by SourceTransformer functions. */
 @Getter
-public final class Message {
+public class Message {
   private static final String[] DROP_TAGS = {"U+005C__DROP__"};
   private final String[] keys;
   private final byte[] value;

--- a/src/main/java/io/numaproj/numaflow/sourcetransformer/Message.java
+++ b/src/main/java/io/numaproj/numaflow/sourcetransformer/Message.java
@@ -1,71 +1,64 @@
 package io.numaproj.numaflow.sourcetransformer;
 
 import lombok.Getter;
+import lombok.AccessLevel;
 
 import java.time.Instant;
 
-
-/**
- * Message is used to wrap the data return by SourceTransformer functions.
- */
-@Getter
+/** Message is used to wrap the data return by SourceTransformer functions. */
+@Getter(AccessLevel.PROTECTED)
 public class Message {
-    public static final String DROP = "U+005C__DROP__";
-    private final String[] keys;
-    private final byte[] value;
-    private final Instant eventTime;
-    private final String[] tags;
+  public static final String DROP = "U+005C__DROP__";
+  private final String[] keys;
+  private final byte[] value;
+  private final Instant eventTime;
+  private final String[] tags;
 
-    /**
-     * used to create Message with value, eventTime, keys and tags(used for conditional forwarding)
-     *
-     * @param value message value
-     * @param eventTime message eventTime
-     * @param keys message keys
-     * @param tags message tags which will be used for conditional forwarding
-     */
-    public Message(byte[] value, Instant eventTime, String[] keys, String[] tags) {
-        this.keys = keys;
-        this.value = value;
-        this.tags = tags;
-        this.eventTime = eventTime;
-    }
+  /**
+   * used to create Message with value, eventTime, keys and tags(used for conditional forwarding)
+   *
+   * @param value message value
+   * @param eventTime message eventTime
+   * @param keys message keys
+   * @param tags message tags which will be used for conditional forwarding
+   */
+  public Message(byte[] value, Instant eventTime, String[] keys, String[] tags) {
+    this.keys = keys;
+    this.value = value;
+    this.tags = tags;
+    this.eventTime = eventTime;
+  }
 
-    /**
-     * used to create Message with value and eventTime.
-     *
-     * @param value message value
-     * @param eventTime message eventTime
-     */
-    public Message(byte[] value, Instant eventTime) {
-        this(value, eventTime, null, null);
-    }
+  /**
+   * used to create Message with value and eventTime.
+   *
+   * @param value message value
+   * @param eventTime message eventTime
+   */
+  public Message(byte[] value, Instant eventTime) {
+    this(value, eventTime, null, null);
+  }
 
-    /**
-     * used to create Message with value, eventTime and keys
-     *
-     * @param value message value
-     * @param eventTime message eventTime
-     * @param keys message keys
-     */
-    public Message(byte[] value, Instant eventTime, String[] keys) {
-        this(value, eventTime, keys, null);
-    }
+  /**
+   * used to create Message with value, eventTime and keys
+   *
+   * @param value message value
+   * @param eventTime message eventTime
+   * @param keys message keys
+   */
+  public Message(byte[] value, Instant eventTime, String[] keys) {
+    this(value, eventTime, keys, null);
+  }
 
-    /**
-     * creates a Message which will be dropped.
-     *
-     * @param eventTime message eventTime is required because even though a message is dropped,
-     *         we consider it as being processed, hence it should be counted in the watermark calculation
-     *         using the provided event time.
-     *
-     * @return returns the Message which will be dropped
-     */
-    public static Message toDrop(Instant eventTime) {
-        return new Message(
-                new byte[0],
-                eventTime,
-                null,
-                new String[]{DROP});
-    }
+  /**
+   * creates a Message which will be dropped.
+   *
+   * @param eventTime message eventTime is required because even though a message is dropped, we
+   *     consider it as being processed, hence it should be counted in the watermark calculation
+   *     using the provided event time.
+   * @return returns the Message which will be dropped
+   */
+  public static Message toDrop(Instant eventTime) {
+    return new Message(new byte[0], eventTime, null, new String[] {DROP});
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/sourcetransformer/Message.java
+++ b/src/main/java/io/numaproj/numaflow/sourcetransformer/Message.java
@@ -1,14 +1,13 @@
 package io.numaproj.numaflow.sourcetransformer;
 
-import lombok.Getter;
-import lombok.AccessLevel;
-
 import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Getter;
 
 /** Message is used to wrap the data return by SourceTransformer functions. */
 @Getter(AccessLevel.PROTECTED)
 public class Message {
-  public static final String DROP = "U+005C__DROP__";
+  private static final String[] DROP_TAGS = {"U+005C__DROP__"};
   private final String[] keys;
   private final byte[] value;
   private final Instant eventTime;
@@ -59,6 +58,6 @@ public class Message {
    * @return returns the Message which will be dropped
    */
   public static Message toDrop(Instant eventTime) {
-    return new Message(new byte[0], eventTime, null, new String[] {DROP});
+    return new Message(new byte[0], eventTime, null, DROP_TAGS);
   }
 }

--- a/src/main/java/io/numaproj/numaflow/sourcetransformer/Message.java
+++ b/src/main/java/io/numaproj/numaflow/sourcetransformer/Message.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 /** Message is used to wrap the data return by SourceTransformer functions. */
 @Getter(AccessLevel.PROTECTED)
-public class Message {
+public final class Message {
   private static final String[] DROP_TAGS = {"U+005C__DROP__"};
   private final String[] keys;
   private final byte[] value;

--- a/src/main/java/io/numaproj/numaflow/sourcetransformer/Message.java
+++ b/src/main/java/io/numaproj/numaflow/sourcetransformer/Message.java
@@ -1,11 +1,10 @@
 package io.numaproj.numaflow.sourcetransformer;
 
 import java.time.Instant;
-import lombok.AccessLevel;
 import lombok.Getter;
 
 /** Message is used to wrap the data return by SourceTransformer functions. */
-@Getter(AccessLevel.PROTECTED)
+@Getter
 public final class Message {
   private static final String[] DROP_TAGS = {"U+005C__DROP__"};
   private final String[] keys;

--- a/src/main/java/io/numaproj/numaflow/sourcetransformer/MessageList.java
+++ b/src/main/java/io/numaproj/numaflow/sourcetransformer/MessageList.java
@@ -9,7 +9,7 @@ import lombok.Singular;
 /** MessageList is used to return the list of Messages from SourceTransformer functions. */
 @Getter
 @Builder(builderMethodName = "newBuilder")
-public final class MessageList {
+public class MessageList {
 
   @Singular("addMessage")
   private List<Message> messages;

--- a/src/main/java/io/numaproj/numaflow/sourcetransformer/MessageList.java
+++ b/src/main/java/io/numaproj/numaflow/sourcetransformer/MessageList.java
@@ -3,39 +3,34 @@ package io.numaproj.numaflow.sourcetransformer;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Singular;
+import lombok.AccessLevel;
 
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * MessageList is used to return the list of Messages from SourceTransformer functions.
- */
-
-@Getter
+/** MessageList is used to return the list of Messages from SourceTransformer functions. */
+@Getter(AccessLevel.PROTECTED)
 @Builder(builderMethodName = "newBuilder")
 public class MessageList {
 
-    @Singular("addMessage")
-    private List<Message> messages;
+  @Singular("addMessage")
+  private List<Message> messages;
 
+  /** Builder to build MessageList */
+  public static class MessageListBuilder {
     /**
-     * Builder to build MessageList
+     * @param messages to append all the messages to MessageList
+     * @return returns the builder
      */
-    public static class MessageListBuilder {
-        /**
-         * @param messages to append all the messages to MessageList
-         *
-         * @return returns the builder
-         */
-        public MessageListBuilder addAllMessages(Iterable<Message> messages) {
-            if (this.messages == null) {
-                this.messages = new ArrayList<>();
-            }
+    public MessageListBuilder addAllMessages(Iterable<Message> messages) {
+      if (this.messages == null) {
+        this.messages = new ArrayList<>();
+      }
 
-            for (Message message : messages) {
-                this.messages.add(message);
-            }
-            return this;
-        }
+      for (Message message : messages) {
+        this.messages.add(message);
+      }
+      return this;
     }
+  }
 }

--- a/src/main/java/io/numaproj/numaflow/sourcetransformer/MessageList.java
+++ b/src/main/java/io/numaproj/numaflow/sourcetransformer/MessageList.java
@@ -1,17 +1,16 @@
 package io.numaproj.numaflow.sourcetransformer;
 
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Singular;
-import lombok.AccessLevel;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /** MessageList is used to return the list of Messages from SourceTransformer functions. */
 @Getter(AccessLevel.PROTECTED)
 @Builder(builderMethodName = "newBuilder")
-public class MessageList {
+public final class MessageList {
 
   @Singular("addMessage")
   private List<Message> messages;

--- a/src/main/java/io/numaproj/numaflow/sourcetransformer/MessageList.java
+++ b/src/main/java/io/numaproj/numaflow/sourcetransformer/MessageList.java
@@ -2,13 +2,12 @@ package io.numaproj.numaflow.sourcetransformer;
 
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Singular;
 
 /** MessageList is used to return the list of Messages from SourceTransformer functions. */
-@Getter(AccessLevel.PROTECTED)
+@Getter
 @Builder(builderMethodName = "newBuilder")
 public final class MessageList {
 

--- a/src/test/java/io/numaproj/numaflow/sinker/ServerTest.java
+++ b/src/test/java/io/numaproj/numaflow/sinker/ServerTest.java
@@ -1,5 +1,8 @@
 package io.numaproj.numaflow.sinker;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.google.protobuf.ByteString;
 import io.grpc.ManagedChannel;
 import io.grpc.inprocess.InProcessChannelBuilder;
@@ -8,6 +11,8 @@ import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
 import io.numaproj.numaflow.sink.v1.SinkGrpc;
 import io.numaproj.numaflow.sink.v1.SinkOuterClass;
+import java.util.Arrays;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
 import org.junit.Before;
@@ -16,148 +21,141 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import java.util.Arrays;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 @Slf4j
 @RunWith(JUnit4.class)
 public class ServerTest {
-    private final static String processedIdSuffix = "-id-processed";
-    @Rule
-    public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
-    private Server server;
-    private ManagedChannel inProcessChannel;
+  private static final String processedIdSuffix = "-id-processed";
+  @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+  private Server server;
+  private ManagedChannel inProcessChannel;
 
-    @Before
-    public void setUp() throws Exception {
-        String serverName = InProcessServerBuilder.generateName();
+  @Before
+  public void setUp() throws Exception {
+    String serverName = InProcessServerBuilder.generateName();
 
-        GRPCConfig grpcServerConfig = GRPCConfig.newBuilder()
-                .maxMessageSize(Constants.DEFAULT_MESSAGE_SIZE)
-                .socketPath(Constants.DEFAULT_SOCKET_PATH)
-                .infoFilePath("/tmp/numaflow-test-server-info)")
+    GRPCConfig grpcServerConfig =
+        GRPCConfig.newBuilder()
+            .maxMessageSize(Constants.DEFAULT_MESSAGE_SIZE)
+            .socketPath(Constants.DEFAULT_SOCKET_PATH)
+            .infoFilePath("/tmp/numaflow-test-server-info)")
+            .build();
+
+    server = new Server(grpcServerConfig, new TestSinkFn(), null, serverName);
+
+    server.start();
+
+    inProcessChannel =
+        grpcCleanup.register(InProcessChannelBuilder.forName(serverName).directExecutor().build());
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    server.stop();
+  }
+
+  @Test
+  public void sinkerSuccess() {
+    int batchSize = 6;
+    int numBatches = 8;
+    // create an output stream observer
+    SinkOutputStreamObserver outputStreamObserver = new SinkOutputStreamObserver();
+
+    StreamObserver<SinkOuterClass.SinkRequest> inputStreamObserver =
+        SinkGrpc.newStub(inProcessChannel).sinkFn(outputStreamObserver);
+
+    String actualId = "sink_test_id";
+    String expectedId = actualId + processedIdSuffix;
+
+    // Send a handshake request
+    SinkOuterClass.SinkRequest handshakeRequest =
+        SinkOuterClass.SinkRequest.newBuilder()
+            .setHandshake(SinkOuterClass.Handshake.newBuilder().setSot(true).build())
+            .build();
+    inputStreamObserver.onNext(handshakeRequest);
+
+    for (int i = 1; i <= batchSize * numBatches; i++) {
+      String[] keys;
+      if (i < batchSize * numBatches) {
+        keys = new String[] {"valid-key"};
+      } else {
+        keys = new String[] {"invalid-key"};
+      }
+
+      SinkOuterClass.SinkRequest.Request request =
+          SinkOuterClass.SinkRequest.Request.newBuilder()
+              .setValue(ByteString.copyFromUtf8(String.valueOf(i)))
+              .setId(actualId)
+              .addAllKeys(List.of(keys))
+              .build();
+
+      SinkOuterClass.SinkRequest sinkRequest =
+          SinkOuterClass.SinkRequest.newBuilder().setRequest(request).build();
+      inputStreamObserver.onNext(sinkRequest);
+
+      // If it's the end of the batch, send an EOT message
+      if (i % batchSize == 0) {
+        SinkOuterClass.SinkRequest eotRequest =
+            SinkOuterClass.SinkRequest.newBuilder()
+                .setStatus(SinkOuterClass.TransmissionStatus.newBuilder().setEot(true).build())
                 .build();
-
-        server = new Server(
-                grpcServerConfig,
-                new TestSinkFn(),
-                null,
-                serverName);
-
-        server.start();
-
-        inProcessChannel = grpcCleanup.register(InProcessChannelBuilder
-                .forName(serverName)
-                .directExecutor()
-                .build());
+        inputStreamObserver.onNext(eotRequest);
+      }
     }
 
-    @After
-    public void tearDown() throws Exception {
-        server.stop();
+    inputStreamObserver.onCompleted();
+
+    while (!outputStreamObserver.completed.get())
+      ;
+    List<SinkOuterClass.SinkResponse> responseList = outputStreamObserver.getSinkResponse();
+    // We expect numBatches * 2 + 1 responses,
+    // with the first one being the handshake response
+    // numBatches responses for the EOT messages
+    // numBatches responses for all the batches.
+    assertEquals(numBatches * 2 + 1, responseList.size());
+    // first response is the handshake response
+    assertTrue(responseList.get(0).getHandshake().getSot());
+    responseList = responseList.subList(1, responseList.size());
+    for (SinkOuterClass.SinkResponse response : responseList) {
+      response
+          .getResultsList()
+          .forEach(
+              result -> {
+                if (result.getStatus() == SinkOuterClass.Status.FAILURE) {
+                  assertEquals("error message", result.getErrMsg());
+                  return;
+                }
+                assertEquals(result.getId(), expectedId);
+                assertEquals(SinkOuterClass.Status.SUCCESS, result.getStatus());
+              });
     }
+  }
 
-    @Test
-    public void sinkerSuccess() {
-        //create an output stream observer
-        SinkOutputStreamObserver outputStreamObserver = new SinkOutputStreamObserver();
+  @Slf4j
+  private static class TestSinkFn extends Sinker {
+    @Override
+    public ResponseList processMessages(DatumIterator datumIterator) {
+      ResponseList.ResponseListBuilder builder = ResponseList.newBuilder();
 
-        StreamObserver<SinkOuterClass.SinkRequest> inputStreamObserver = SinkGrpc
-                .newStub(inProcessChannel)
-                .sinkFn(outputStreamObserver);
-
-        String actualId = "sink_test_id";
-        String expectedId = actualId + processedIdSuffix;
-
-        // Send a handshake request
-        SinkOuterClass.SinkRequest handshakeRequest = SinkOuterClass.SinkRequest.newBuilder()
-                .setHandshake(SinkOuterClass.Handshake.newBuilder().setSot(true).build())
-                .build();
-        inputStreamObserver.onNext(handshakeRequest);
-
-        for (int i = 1; i <= 100; i++) {
-            String[] keys;
-            if (i < 100) {
-                keys = new String[]{"valid-key"};
-            } else {
-                keys = new String[]{"invalid-key"};
-            }
-
-            SinkOuterClass.SinkRequest.Request request = SinkOuterClass.SinkRequest.Request
-                    .newBuilder()
-                    .setValue(ByteString.copyFromUtf8(String.valueOf(i)))
-                    .setId(actualId)
-                    .addAllKeys(List.of(keys))
-                    .build();
-
-            SinkOuterClass.SinkRequest sinkRequest = SinkOuterClass.SinkRequest.newBuilder()
-                    .setRequest(request).build();
-            inputStreamObserver.onNext(sinkRequest);
-
-            // If it's the end of the batch, send an EOT message
-            if (i % 10 == 0) {
-                SinkOuterClass.SinkRequest eotRequest = SinkOuterClass.SinkRequest.newBuilder()
-                        .setStatus(SinkOuterClass.TransmissionStatus
-                                .newBuilder()
-                                .setEot(true)
-                                .build())
-                        .build();
-                inputStreamObserver.onNext(eotRequest);
-            }
+      while (true) {
+        Datum datum;
+        try {
+          datum = datumIterator.next();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          continue;
         }
-
-        inputStreamObserver.onCompleted();
-
-        while (!outputStreamObserver.completed.get()) ;
-        List<SinkOuterClass.SinkResponse> responseList = outputStreamObserver.getSinkResponse();
-        assertEquals(21, responseList.size());
-        // first response is the handshake response
-        assertTrue(responseList.get(0).getHandshake().getSot());
-
-        responseList = responseList.subList(1, responseList.size());
-        var response = responseList.get(0);
-        response.getResultsList().forEach(result -> {
-            if (result.getStatus() == SinkOuterClass.Status.FAILURE) {
-                assertEquals(result.getErrMsg(), "error message");
-                return;
-            }
-            assertEquals(result.getId(), expectedId);
-            assertEquals(result.getStatus(), SinkOuterClass.Status.SUCCESS);
-        });
-    }
-
-    @Slf4j
-    private static class TestSinkFn extends Sinker {
-        @Override
-        public ResponseList processMessages(DatumIterator datumIterator) {
-            ResponseList.ResponseListBuilder builder = ResponseList.newBuilder();
-
-            while (true) {
-                Datum datum;
-                try {
-                    datum = datumIterator.next();
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    continue;
-                }
-                if (datum == null) {
-                    break;
-                }
-                if (Arrays.equals(datum.getKeys(), new String[]{"invalid-key"})) {
-                    builder.addResponse(Response.responseFailure(
-                            datum.getId() + processedIdSuffix,
-                            "error message"));
-                    continue;
-                }
-                log.info(new String(datum.getValue()));
-                builder.addResponse(Response.responseOK(datum.getId() + processedIdSuffix));
-            }
-
-            return builder.build();
+        if (datum == null) {
+          break;
         }
+        if (Arrays.equals(datum.getKeys(), new String[] {"invalid-key"})) {
+          builder.addResponse(
+              Response.responseFailure(datum.getId() + processedIdSuffix, "error message"));
+          continue;
+        }
+        builder.addResponse(Response.responseOK(datum.getId() + processedIdSuffix));
+      }
 
+      return builder.build();
     }
+  }
 }


### PR DESCRIPTION
Applying some Java best practices that I learnt from [Effective Java](https://www.oreilly.com/library/view/effective-java-3rd/9780134686097/). Will selectively apply more as I continue reading.

* Use [try-with-resources](https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html) to write server info file.

We no longer need to close FileWriter by ourselves because FileWriter implements `java.lang.AutoCloseable`. The try-with-resources will automatically close it after finish writing, using the native FileWriter implementation of AutoCloseable.

* Avoid unnecessary boxing/unboxing for sink response.

In class Response, `private final Boolean success;` is changed to `private final boolean success;` such that when we new a Response object with a primitive boolean value, Java doesn't need to perform unnecessary boxing. We don't have a case where success can be null.

~* Mark Message getters as protected.~

~Such that we don't expose them to users. This is technically a backward-incompatible change if an existing user uses getters. Normally, Messages are instantiated right before sending to the next processing unit. I cannot think of a use case for getter. If we don't expect user to use getter, I think we should not expose it.~

* Make DROP_TAGS as a `static final`.

Such that it's shared by all `toDrop` calls. We don't need to instantiate a new string array every time user uses `toDrop`.

* Use defensive copy when constructing Message objects.

Message is an immutable class. Without defensive copying, user could modify the content of a Message unknowingly by modifying the input reference params.  

* Use private constructor for utility classes.

A utility class should never be instantiated.

* Mark Message and Response class as final.

We don't expect Message and Response class to be extended.