### PR TITLE
fix: revert sideinput Constant back to public

### DIFF
--- a/src/main/java/io/numaproj/numaflow/sideinput/Constants.java
+++ b/src/main/java/io/numaproj/numaflow/sideinput/Constants.java
@@ -7,9 +7,4 @@ class Constants {
   static final String DEFAULT_HOST = "localhost";
   static int DEFAULT_MESSAGE_SIZE = 1024 * 1024 * 64;
   static int DEFAULT_PORT = 50051;
-
-  // Private constructor to prevent instantiation
-  private Constants() {
-    throw new IllegalStateException("Utility class 'Constants' should not be instantiated");
-  }
 }

--- a/src/main/java/io/numaproj/numaflow/sideinput/Constants.java
+++ b/src/main/java/io/numaproj/numaflow/sideinput/Constants.java
@@ -1,10 +1,15 @@
 package io.numaproj.numaflow.sideinput;
 
-class Constants {
+public class Constants {
   public static final String SIDE_INPUT_DIR = "/var/numaflow/side-inputs";
   static final String DEFAULT_SOCKET_PATH = "/var/run/numaflow/sideinput.sock";
   static final String DEFAULT_SERVER_INFO_FILE_PATH = "/var/run/numaflow/sideinput-server-info";
   static final String DEFAULT_HOST = "localhost";
   static int DEFAULT_MESSAGE_SIZE = 1024 * 1024 * 64;
   static int DEFAULT_PORT = 50051;
+
+  // Private constructor to prevent instantiation
+  private Constants() {
+    throw new IllegalStateException("Utility class 'Constants' should not be instantiated");
+  }
 }


### PR DESCRIPTION
 Because `Constants.SIDE_INPUT_DIR` is exposed to user. Fixing failed example: https://github.com/numaproj/numaflow-java/actions/runs/14812238370/job/41588350230