### PR TITLE
chore: add building examples as part of CI

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -17,6 +17,8 @@ jobs:
           distribution: 'temurin'
       - name: Build with Maven, run unit tests and the coverage check
         run: mvn clean install
+      - name: Build Examples
+        run: cd examples && mvn clean install
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/examples/.editorconfig
+++ b/examples/.editorconfig
@@ -1,0 +1,35 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+max_line_length = 100
+
+[*.java]
+indent_size = 4
+indent_style = space
+tab_width = 4
+ij_continuation_indent_size = 8
+ij_java_binary_operation_sign_on_next_line = true
+ij_java_binary_operation_wrap = normal
+ij_java_call_parameters_new_line_after_left_paren = true
+ij_java_call_parameters_wrap = on_every_item
+ij_java_class_count_to_use_import_on_demand = 9999
+ij_java_doc_add_blank_line_after_param_comments = true
+ij_java_doc_add_blank_line_after_return = true
+ij_java_doc_align_exception_comments = false
+ij_java_doc_align_param_comments = false
+ij_java_doc_do_not_wrap_if_one_line = true
+ij_java_doc_enable_formatting = true
+ij_java_doc_indent_on_continuation = true
+ij_java_doc_keep_empty_lines = true
+ij_java_doc_preserve_line_breaks = false
+ij_java_layout_static_imports_separately = true
+ij_java_method_call_chain_wrap = on_every_item
+ij_java_method_parameters_new_line_after_left_paren = true
+ij_java_method_parameters_wrap = on_every_item
+ij_java_names_count_to_use_import_on_demand = 9999
+ij_java_spaces_around_equality_operators = true
+ij_java_variable_annotation_wrap = normal
+ij_java_wrap_first_method_in_call_chain = true

--- a/examples/src/test/java/io/numaproj/numaflow/examples/server/ServerTest.java
+++ b/examples/src/test/java/io/numaproj/numaflow/examples/server/ServerTest.java
@@ -29,244 +29,241 @@ import org.junit.jupiter.api.TestMethodOrder;
 @Slf4j
 public class ServerTest {
 
-    @Test
-    @Order(1)
-    public void testMapServerInvocation() {
-        MapperTestKit mapperTestKit = new MapperTestKit(new EvenOddFunction());
-        try {
-            mapperTestKit.startServer();
-        } catch (Exception e) {
-            log.error("Failed to start server", e);
-            Assertions.fail("Failed to start server");
-        }
-
-        // Create a client which can send requests to the server
-        MapperTestKit.Client client = new MapperTestKit.Client();
-        MapperTestKit.TestDatum datum = MapperTestKit.TestDatum
-                .builder()
-                .value("2".getBytes())
-                .build();
-        MessageList result = client.sendRequest(new String[]{}, datum);
-
-        List<Message> messages = result.getMessages();
-        Assertions.assertEquals(1, messages.size());
-        Assertions.assertEquals("even", messages.get(0).getKeys()[0]);
-
-        try {
-            client.close();
-            mapperTestKit.stopServer();
-        } catch (Exception e) {
-            log.error("Failed to stop server", e);
-            Assertions.fail("Failed to stop server");
-        }
+  @Test
+  @Order(1)
+  public void testMapServerInvocation() {
+    MapperTestKit mapperTestKit = new MapperTestKit(new EvenOddFunction());
+    try {
+      mapperTestKit.startServer();
+    } catch (Exception e) {
+      log.error("Failed to start server", e);
+      Assertions.fail("Failed to start server");
     }
 
-    @Test
-    @Order(2)
-    public void testFlatMapServerInvocation() {
-        MapperTestKit mapperTestKit = new MapperTestKit(new FlatMapFunction());
-        try {
-            mapperTestKit.startServer();
-        } catch (Exception e) {
-            log.error("Failed to start server", e);
-        }
+    // Create a client which can send requests to the server
+    MapperTestKit.Client client = new MapperTestKit.Client();
+    MapperTestKit.TestDatum datum = MapperTestKit.TestDatum.builder().value("2".getBytes()).build();
+    MessageList result = client.sendRequest(new String[] {}, datum);
 
-        MapperTestKit.Client client = new MapperTestKit.Client();
-        MapperTestKit.TestDatum datum = MapperTestKit.TestDatum
-                .builder()
-                .value("apple,banana,carrot".getBytes())
-                .build();
+    List<Message> messages = result.getMessages();
+    Assertions.assertEquals(1, messages.size());
+    Assertions.assertEquals("even", messages.get(0).getKeys()[0]);
 
-        MessageList result = client.sendRequest(new String[]{}, datum);
+    try {
+      client.close();
+      mapperTestKit.stopServer();
+    } catch (Exception e) {
+      log.error("Failed to stop server", e);
+      Assertions.fail("Failed to stop server");
+    }
+  }
 
-        List<Message> messages = result.getMessages();
-        Assertions.assertEquals(3, messages.size());
-
-        Assertions.assertEquals("apple", new String(messages.get(0).getValue()));
-        Assertions.assertEquals("banana", new String(messages.get(1).getValue()));
-        Assertions.assertEquals("carrot", new String(messages.get(2).getValue()));
-
-        try {
-            client.close();
-            mapperTestKit.stopServer();
-        } catch (Exception e) {
-            log.error("Failed to stop server", e);
-        }
+  @Test
+  @Order(2)
+  public void testFlatMapServerInvocation() {
+    MapperTestKit mapperTestKit = new MapperTestKit(new FlatMapFunction());
+    try {
+      mapperTestKit.startServer();
+    } catch (Exception e) {
+      log.error("Failed to start server", e);
     }
 
-    @Test
-    @Order(3)
-    public void testReduceServerInvocation() {
-        SumFactory sumFactory = new SumFactory();
+    MapperTestKit.Client client = new MapperTestKit.Client();
+    MapperTestKit.TestDatum datum =
+        MapperTestKit.TestDatum.builder().value("apple,banana,carrot".getBytes()).build();
 
-        ReducerTestKit reducerTestKit = new ReducerTestKit(sumFactory);
+    MessageList result = client.sendRequest(new String[] {}, datum);
 
-        // Start the server
-        try {
-            reducerTestKit.startServer();
-        } catch (Exception e) {
-            Assertions.fail("Failed to start server");
-        }
+    List<Message> messages = result.getMessages();
+    Assertions.assertEquals(3, messages.size());
 
-        // List of datum to be sent to the server
-        // create 10 datum with values 1 to 10
-        List<Datum> datumList = new ArrayList<>();
-        for (int i = 1; i <= 10; i++) {
-            datumList.add(ReducerTestKit.TestDatum
-                    .builder()
-                    .value(Integer.toString(i).getBytes())
-                    .build());
-        }
+    Assertions.assertEquals("apple", new String(messages.get(0).getValue()));
+    Assertions.assertEquals("banana", new String(messages.get(1).getValue()));
+    Assertions.assertEquals("carrot", new String(messages.get(2).getValue()));
 
-        // create a client and send requests to the server
-        ReducerTestKit.Client client = new ReducerTestKit.Client();
+    try {
+      client.close();
+      mapperTestKit.stopServer();
+    } catch (Exception e) {
+      log.error("Failed to stop server", e);
+    }
+  }
 
-        ReducerTestKit.TestReduceRequest testReduceRequest = ReducerTestKit.TestReduceRequest
-                .builder()
-                .datumList(datumList)
-                .keys(new String[]{"test-key"})
-                .startTime(Instant.ofEpochSecond(60000))
-                .endTime(Instant.ofEpochSecond(60010))
-                .build();
+  @Test
+  @Order(3)
+  public void testReduceServerInvocation() {
+    SumFactory sumFactory = new SumFactory();
 
-        try {
-            io.numaproj.numaflow.reducer.MessageList messageList = client.sendReduceRequest(
-                    testReduceRequest);
-            // check if the response is correct
-            if (messageList.getMessages().size() != 1) {
-                Assertions.fail("Expected 1 message in the response");
-            }
-            Assertions.assertEquals("55", new String(messageList.getMessages().get(0).getValue()));
+    ReducerTestKit reducerTestKit = new ReducerTestKit(sumFactory);
 
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assertions.fail("Failed to send request to server - ");
-        }
-
-        // Stop the server
-        try {
-            client.close();
-            reducerTestKit.stopServer();
-        } catch (InterruptedException e) {
-            Assertions.fail("Failed to stop server");
-        }
+    // Start the server
+    try {
+      reducerTestKit.startServer();
+    } catch (Exception e) {
+      Assertions.fail("Failed to start server");
     }
 
-    @Test
-    @Order(4)
-    public void testSinkServerInvocation() {
-        int datumCount = 10;
-        SinkerTestKit sinkerTestKit = new SinkerTestKit(new SimpleSink());
-
-        // Start the server
-        try {
-            sinkerTestKit.startServer();
-        } catch (Exception e) {
-            Assertions.fail("Failed to start server");
-        }
-
-        // Create a test datum iterator with 10 messages
-        SinkerTestKit.TestListIterator testListIterator = new SinkerTestKit.TestListIterator();
-        for (int i = 0; i < datumCount; i++) {
-            testListIterator.addDatum(SinkerTestKit.TestDatum
-                    .builder()
-                    .id("id-" + i)
-                    .value(("value-" + i).getBytes())
-                    .headers(Map.of("test-key", "test-value"))
-                    .build());
-        }
-
-        SinkerTestKit.Client client = new SinkerTestKit.Client();
-        try {
-            ResponseList responseList = client.sendRequest(testListIterator);
-            Assertions.assertEquals(datumCount, responseList.getResponses().size());
-            for (Response response : responseList.getResponses()) {
-                Assertions.assertEquals(true, response.isSuccess());
-            }
-        } catch (Exception e) {
-            Assertions.fail("Failed to send requests");
-        }
-
-        // Stop the server
-        try {
-            client.close();
-            sinkerTestKit.stopServer();
-        } catch (InterruptedException e) {
-            Assertions.fail("Failed to stop server");
-        }
-
-        // we can add the logic to verify if the messages were
-        // successfully written to the sink(could be a file, database, etc.)
+    // List of datum to be sent to the server
+    // create 10 datum with values 1 to 10
+    List<Datum> datumList = new ArrayList<>();
+    for (int i = 1; i <= 10; i++) {
+      datumList.add(
+          ReducerTestKit.TestDatum.builder().value(Integer.toString(i).getBytes()).build());
     }
-// FIXME: once tester kit changes are done for bidirectional streaming source
-//    @Ignore
-//    @Test
-//    @Order(5)
-//    public void testSourceServerInvocation() {
-//        SimpleSource simpleSource = new SimpleSource();
-//
-//        SourcerTestKit sourcerTestKit = new SourcerTestKit(simpleSource);
-//        try {
-//            sourcerTestKit.startServer();
-//        } catch (Exception e) {
-//            Assertions.fail("Failed to start server");
-//        }
-//
-//        // create a client to send requests to the server
-//        SourcerTestKit.Client sourcerClient = new SourcerTestKit.Client();
-//        // create a test observer to receive messages from the server
-//        SourcerTestKit.TestListBasedObserver testObserver = new SourcerTestKit.TestListBasedObserver();
-//        // create a read request with count 10 and timeout 1 second
-//        SourcerTestKit.TestReadRequest testReadRequest = SourcerTestKit.TestReadRequest.builder()
-//                .count(10).timeout(Duration.ofSeconds(1)).build();
-//
-//        try {
-//            sourcerClient.sendReadRequest(testReadRequest, testObserver);
-//            Assertions.assertEquals(10, testObserver.getMessages().size());
-//        } catch (Exception e) {
-//            Assertions.fail("Failed to send request to server");
-//        }
-//
-//        try {
-//            sourcerClient.close();
-//            sourcerTestKit.stopServer();
-//        } catch (InterruptedException e) {
-//            Assertions.fail("Failed to stop server");
-//        }
-//    }
 
-    @Test
-    @Order(6)
-    public void testSourceTransformerServerInvocation() {
-        SourceTransformerTestKit sourceTransformerTestKit = new SourceTransformerTestKit(new EventTimeFilterFunction());
-        try {
-            sourceTransformerTestKit.startServer();
-        } catch (Exception e) {
-            Assertions.fail("Failed to start server");
-        }
+    // create a client and send requests to the server
+    ReducerTestKit.Client client = new ReducerTestKit.Client();
 
-        // Create a client which can send requests to the server
-        SourceTransformerTestKit.Client client = new SourceTransformerTestKit.Client();
+    ReducerTestKit.TestReduceRequest testReduceRequest =
+        ReducerTestKit.TestReduceRequest.builder()
+            .datumList(datumList)
+            .keys(new String[] {"test-key"})
+            .startTime(Instant.ofEpochSecond(60000))
+            .endTime(Instant.ofEpochSecond(60010))
+            .build();
 
-        SourceTransformerTestKit.TestDatum datum = SourceTransformerTestKit.TestDatum.builder()
-                .eventTime(Instant.ofEpochMilli(1640995200000L))
-                .value("test".getBytes())
-                .build();
-        io.numaproj.numaflow.sourcetransformer.MessageList result = client.sendRequest(
-                new String[]{},
-                datum);
+    try {
+      io.numaproj.numaflow.reducer.MessageList messageList =
+          client.sendReduceRequest(testReduceRequest);
+      // check if the response is correct
+      if (messageList.getMessages().size() != 1) {
+        Assertions.fail("Expected 1 message in the response");
+      }
+      Assertions.assertEquals("55", new String(messageList.getMessages().get(0).getValue()));
 
-        List<io.numaproj.numaflow.sourcetransformer.Message> messages = result.getMessages();
-        Assertions.assertEquals(1, messages.size());
-
-        Assertions.assertEquals("test", new String(messages.get(0).getValue()));
-        Assertions.assertEquals("within_year_2022", messages.get(0).getTags()[0]);
-
-        try {
-            client.close();
-            sourceTransformerTestKit.stopServer();
-        } catch (Exception e) {
-            Assertions.fail("Failed to stop server");
-        }
+    } catch (Exception e) {
+      e.printStackTrace();
+      Assertions.fail("Failed to send request to server - ");
     }
+
+    // Stop the server
+    try {
+      client.close();
+      reducerTestKit.stopServer();
+    } catch (InterruptedException e) {
+      Assertions.fail("Failed to stop server");
+    }
+  }
+
+  @Test
+  @Order(4)
+  public void testSinkServerInvocation() {
+    int datumCount = 10;
+    SinkerTestKit sinkerTestKit = new SinkerTestKit(new SimpleSink());
+
+    // Start the server
+    try {
+      sinkerTestKit.startServer();
+    } catch (Exception e) {
+      Assertions.fail("Failed to start server");
+    }
+
+    // Create a test datum iterator with 10 messages
+    SinkerTestKit.TestListIterator testListIterator = new SinkerTestKit.TestListIterator();
+    for (int i = 0; i < datumCount; i++) {
+      testListIterator.addDatum(
+          SinkerTestKit.TestDatum.builder()
+              .id("id-" + i)
+              .value(("value-" + i).getBytes())
+              .headers(Map.of("test-key", "test-value"))
+              .build());
+    }
+
+    SinkerTestKit.Client client = new SinkerTestKit.Client();
+    try {
+      ResponseList responseList = client.sendRequest(testListIterator);
+      Assertions.assertEquals(datumCount, responseList.getResponses().size());
+      for (Response response : responseList.getResponses()) {
+        Assertions.assertEquals(true, response.getSuccess());
+      }
+    } catch (Exception e) {
+      Assertions.fail("Failed to send requests");
+    }
+
+    // Stop the server
+    try {
+      client.close();
+      sinkerTestKit.stopServer();
+    } catch (InterruptedException e) {
+      Assertions.fail("Failed to stop server");
+    }
+
+    // we can add the logic to verify if the messages were
+    // successfully written to the sink(could be a file, database, etc.)
+  }
+
+  // FIXME: once tester kit changes are done for bidirectional streaming source
+  //    @Ignore
+  //    @Test
+  //    @Order(5)
+  //    public void testSourceServerInvocation() {
+  //        SimpleSource simpleSource = new SimpleSource();
+  //
+  //        SourcerTestKit sourcerTestKit = new SourcerTestKit(simpleSource);
+  //        try {
+  //            sourcerTestKit.startServer();
+  //        } catch (Exception e) {
+  //            Assertions.fail("Failed to start server");
+  //        }
+  //
+  //        // create a client to send requests to the server
+  //        SourcerTestKit.Client sourcerClient = new SourcerTestKit.Client();
+  //        // create a test observer to receive messages from the server
+  //        SourcerTestKit.TestListBasedObserver testObserver = new
+  // SourcerTestKit.TestListBasedObserver();
+  //        // create a read request with count 10 and timeout 1 second
+  //        SourcerTestKit.TestReadRequest testReadRequest =
+  // SourcerTestKit.TestReadRequest.builder()
+  //                .count(10).timeout(Duration.ofSeconds(1)).build();
+  //
+  //        try {
+  //            sourcerClient.sendReadRequest(testReadRequest, testObserver);
+  //            Assertions.assertEquals(10, testObserver.getMessages().size());
+  //        } catch (Exception e) {
+  //            Assertions.fail("Failed to send request to server");
+  //        }
+  //
+  //        try {
+  //            sourcerClient.close();
+  //            sourcerTestKit.stopServer();
+  //        } catch (InterruptedException e) {
+  //            Assertions.fail("Failed to stop server");
+  //        }
+  //    }
+
+  @Test
+  @Order(6)
+  public void testSourceTransformerServerInvocation() {
+    SourceTransformerTestKit sourceTransformerTestKit =
+        new SourceTransformerTestKit(new EventTimeFilterFunction());
+    try {
+      sourceTransformerTestKit.startServer();
+    } catch (Exception e) {
+      Assertions.fail("Failed to start server");
+    }
+
+    // Create a client which can send requests to the server
+    SourceTransformerTestKit.Client client = new SourceTransformerTestKit.Client();
+
+    SourceTransformerTestKit.TestDatum datum =
+        SourceTransformerTestKit.TestDatum.builder()
+            .eventTime(Instant.ofEpochMilli(1640995200000L))
+            .value("test".getBytes())
+            .build();
+    io.numaproj.numaflow.sourcetransformer.MessageList result =
+        client.sendRequest(new String[] {}, datum);
+
+    List<io.numaproj.numaflow.sourcetransformer.Message> messages = result.getMessages();
+    Assertions.assertEquals(1, messages.size());
+
+    Assertions.assertEquals("test", new String(messages.get(0).getValue()));
+    Assertions.assertEquals("within_year_2022", messages.get(0).getTags()[0]);
+
+    try {
+      client.close();
+      sourceTransformerTestKit.stopServer();
+    } catch (Exception e) {
+      Assertions.fail("Failed to stop server");
+    }
+  }
 }

--- a/examples/src/test/java/io/numaproj/numaflow/examples/server/ServerTest.java
+++ b/examples/src/test/java/io/numaproj/numaflow/examples/server/ServerTest.java
@@ -14,10 +14,6 @@ import io.numaproj.numaflow.sinker.Response;
 import io.numaproj.numaflow.sinker.ResponseList;
 import io.numaproj.numaflow.sinker.SinkerTestKit;
 import io.numaproj.numaflow.sourcetransformer.SourceTransformerTestKit;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.MethodOrderer;
@@ -25,245 +21,256 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @Slf4j
 public class ServerTest {
 
-  @Test
-  @Order(1)
-  public void testMapServerInvocation() {
-    MapperTestKit mapperTestKit = new MapperTestKit(new EvenOddFunction());
-    try {
-      mapperTestKit.startServer();
-    } catch (Exception e) {
-      log.error("Failed to start server", e);
-      Assertions.fail("Failed to start server");
+    @Test
+    @Order(1)
+    public void testMapServerInvocation() {
+        MapperTestKit mapperTestKit = new MapperTestKit(new EvenOddFunction());
+        try {
+            mapperTestKit.startServer();
+        } catch (Exception e) {
+            log.error("Failed to start server", e);
+            Assertions.fail("Failed to start server");
+        }
+
+        // Create a client which can send requests to the server
+        MapperTestKit.Client client = new MapperTestKit.Client();
+        MapperTestKit.TestDatum datum = MapperTestKit.TestDatum
+                .builder()
+                .value("2".getBytes())
+                .build();
+        MessageList result = client.sendRequest(new String[]{}, datum);
+
+        List<Message> messages = result.getMessages();
+        Assertions.assertEquals(1, messages.size());
+        Assertions.assertEquals("even", messages.get(0).getKeys()[0]);
+
+        try {
+            client.close();
+            mapperTestKit.stopServer();
+        } catch (Exception e) {
+            log.error("Failed to stop server", e);
+            Assertions.fail("Failed to stop server");
+        }
     }
 
-    // Create a client which can send requests to the server
-    MapperTestKit.Client client = new MapperTestKit.Client();
-    MapperTestKit.TestDatum datum = MapperTestKit.TestDatum.builder().value("2".getBytes()).build();
-    MessageList result = client.sendRequest(new String[] {}, datum);
+    @Test
+    @Order(2)
+    public void testFlatMapServerInvocation() {
+        MapperTestKit mapperTestKit = new MapperTestKit(new FlatMapFunction());
+        try {
+            mapperTestKit.startServer();
+        } catch (Exception e) {
+            log.error("Failed to start server", e);
+        }
 
-    List<Message> messages = result.getMessages();
-    Assertions.assertEquals(1, messages.size());
-    Assertions.assertEquals("even", messages.get(0).getKeys()[0]);
+        MapperTestKit.Client client = new MapperTestKit.Client();
+        MapperTestKit.TestDatum datum =
+                MapperTestKit.TestDatum.builder().value("apple,banana,carrot".getBytes()).build();
 
-    try {
-      client.close();
-      mapperTestKit.stopServer();
-    } catch (Exception e) {
-      log.error("Failed to stop server", e);
-      Assertions.fail("Failed to stop server");
-    }
-  }
+        MessageList result = client.sendRequest(new String[]{}, datum);
 
-  @Test
-  @Order(2)
-  public void testFlatMapServerInvocation() {
-    MapperTestKit mapperTestKit = new MapperTestKit(new FlatMapFunction());
-    try {
-      mapperTestKit.startServer();
-    } catch (Exception e) {
-      log.error("Failed to start server", e);
-    }
+        List<Message> messages = result.getMessages();
+        Assertions.assertEquals(3, messages.size());
 
-    MapperTestKit.Client client = new MapperTestKit.Client();
-    MapperTestKit.TestDatum datum =
-        MapperTestKit.TestDatum.builder().value("apple,banana,carrot".getBytes()).build();
+        Assertions.assertEquals("apple", new String(messages.get(0).getValue()));
+        Assertions.assertEquals("banana", new String(messages.get(1).getValue()));
+        Assertions.assertEquals("carrot", new String(messages.get(2).getValue()));
 
-    MessageList result = client.sendRequest(new String[] {}, datum);
-
-    List<Message> messages = result.getMessages();
-    Assertions.assertEquals(3, messages.size());
-
-    Assertions.assertEquals("apple", new String(messages.get(0).getValue()));
-    Assertions.assertEquals("banana", new String(messages.get(1).getValue()));
-    Assertions.assertEquals("carrot", new String(messages.get(2).getValue()));
-
-    try {
-      client.close();
-      mapperTestKit.stopServer();
-    } catch (Exception e) {
-      log.error("Failed to stop server", e);
-    }
-  }
-
-  @Test
-  @Order(3)
-  public void testReduceServerInvocation() {
-    SumFactory sumFactory = new SumFactory();
-
-    ReducerTestKit reducerTestKit = new ReducerTestKit(sumFactory);
-
-    // Start the server
-    try {
-      reducerTestKit.startServer();
-    } catch (Exception e) {
-      Assertions.fail("Failed to start server");
+        try {
+            client.close();
+            mapperTestKit.stopServer();
+        } catch (Exception e) {
+            log.error("Failed to stop server", e);
+        }
     }
 
-    // List of datum to be sent to the server
-    // create 10 datum with values 1 to 10
-    List<Datum> datumList = new ArrayList<>();
-    for (int i = 1; i <= 10; i++) {
-      datumList.add(
-          ReducerTestKit.TestDatum.builder().value(Integer.toString(i).getBytes()).build());
+    @Test
+    @Order(3)
+    public void testReduceServerInvocation() {
+        SumFactory sumFactory = new SumFactory();
+
+        ReducerTestKit reducerTestKit = new ReducerTestKit(sumFactory);
+
+        // Start the server
+        try {
+            reducerTestKit.startServer();
+        } catch (Exception e) {
+            Assertions.fail("Failed to start server");
+        }
+
+        // List of datum to be sent to the server
+        // create 10 datum with values 1 to 10
+        List<Datum> datumList = new ArrayList<>();
+        for (int i = 1; i <= 10; i++) {
+            datumList.add(
+                    ReducerTestKit.TestDatum
+                            .builder()
+                            .value(Integer.toString(i).getBytes())
+                            .build());
+        }
+
+        // create a client and send requests to the server
+        ReducerTestKit.Client client = new ReducerTestKit.Client();
+
+        ReducerTestKit.TestReduceRequest testReduceRequest =
+                ReducerTestKit.TestReduceRequest.builder()
+                        .datumList(datumList)
+                        .keys(new String[]{"test-key"})
+                        .startTime(Instant.ofEpochSecond(60000))
+                        .endTime(Instant.ofEpochSecond(60010))
+                        .build();
+
+        try {
+            io.numaproj.numaflow.reducer.MessageList messageList =
+                    client.sendReduceRequest(testReduceRequest);
+            // check if the response is correct
+            if (messageList.getMessages().size() != 1) {
+                Assertions.fail("Expected 1 message in the response");
+            }
+            Assertions.assertEquals("55", new String(messageList.getMessages().get(0).getValue()));
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assertions.fail("Failed to send request to server - ");
+        }
+
+        // Stop the server
+        try {
+            client.close();
+            reducerTestKit.stopServer();
+        } catch (InterruptedException e) {
+            Assertions.fail("Failed to stop server");
+        }
     }
 
-    // create a client and send requests to the server
-    ReducerTestKit.Client client = new ReducerTestKit.Client();
+    @Test
+    @Order(4)
+    public void testSinkServerInvocation() {
+        int datumCount = 10;
+        SinkerTestKit sinkerTestKit = new SinkerTestKit(new SimpleSink());
 
-    ReducerTestKit.TestReduceRequest testReduceRequest =
-        ReducerTestKit.TestReduceRequest.builder()
-            .datumList(datumList)
-            .keys(new String[] {"test-key"})
-            .startTime(Instant.ofEpochSecond(60000))
-            .endTime(Instant.ofEpochSecond(60010))
-            .build();
+        // Start the server
+        try {
+            sinkerTestKit.startServer();
+        } catch (Exception e) {
+            Assertions.fail("Failed to start server");
+        }
 
-    try {
-      io.numaproj.numaflow.reducer.MessageList messageList =
-          client.sendReduceRequest(testReduceRequest);
-      // check if the response is correct
-      if (messageList.getMessages().size() != 1) {
-        Assertions.fail("Expected 1 message in the response");
-      }
-      Assertions.assertEquals("55", new String(messageList.getMessages().get(0).getValue()));
+        // Create a test datum iterator with 10 messages
+        SinkerTestKit.TestListIterator testListIterator = new SinkerTestKit.TestListIterator();
+        for (int i = 0; i < datumCount; i++) {
+            testListIterator.addDatum(
+                    SinkerTestKit.TestDatum.builder()
+                            .id("id-" + i)
+                            .value(("value-" + i).getBytes())
+                            .headers(Map.of("test-key", "test-value"))
+                            .build());
+        }
 
-    } catch (Exception e) {
-      e.printStackTrace();
-      Assertions.fail("Failed to send request to server - ");
+        SinkerTestKit.Client client = new SinkerTestKit.Client();
+        try {
+            ResponseList responseList = client.sendRequest(testListIterator);
+            Assertions.assertEquals(datumCount, responseList.getResponses().size());
+            for (Response response : responseList.getResponses()) {
+                Assertions.assertEquals(true, response.getSuccess());
+            }
+        } catch (Exception e) {
+            Assertions.fail("Failed to send requests");
+        }
+
+        // Stop the server
+        try {
+            client.close();
+            sinkerTestKit.stopServer();
+        } catch (InterruptedException e) {
+            Assertions.fail("Failed to stop server");
+        }
+
+        // we can add the logic to verify if the messages were
+        // successfully written to the sink(could be a file, database, etc.)
     }
 
-    // Stop the server
-    try {
-      client.close();
-      reducerTestKit.stopServer();
-    } catch (InterruptedException e) {
-      Assertions.fail("Failed to stop server");
+    // FIXME: once tester kit changes are done for bidirectional streaming source
+    //    @Ignore
+    //    @Test
+    //    @Order(5)
+    //    public void testSourceServerInvocation() {
+    //        SimpleSource simpleSource = new SimpleSource();
+    //
+    //        SourcerTestKit sourcerTestKit = new SourcerTestKit(simpleSource);
+    //        try {
+    //            sourcerTestKit.startServer();
+    //        } catch (Exception e) {
+    //            Assertions.fail("Failed to start server");
+    //        }
+    //
+    //        // create a client to send requests to the server
+    //        SourcerTestKit.Client sourcerClient = new SourcerTestKit.Client();
+    //        // create a test observer to receive messages from the server
+    //        SourcerTestKit.TestListBasedObserver testObserver = new
+    // SourcerTestKit.TestListBasedObserver();
+    //        // create a read request with count 10 and timeout 1 second
+    //        SourcerTestKit.TestReadRequest testReadRequest =
+    // SourcerTestKit.TestReadRequest.builder()
+    //                .count(10).timeout(Duration.ofSeconds(1)).build();
+    //
+    //        try {
+    //            sourcerClient.sendReadRequest(testReadRequest, testObserver);
+    //            Assertions.assertEquals(10, testObserver.getMessages().size());
+    //        } catch (Exception e) {
+    //            Assertions.fail("Failed to send request to server");
+    //        }
+    //
+    //        try {
+    //            sourcerClient.close();
+    //            sourcerTestKit.stopServer();
+    //        } catch (InterruptedException e) {
+    //            Assertions.fail("Failed to stop server");
+    //        }
+    //    }
+
+    @Test
+    @Order(6)
+    public void testSourceTransformerServerInvocation() {
+        SourceTransformerTestKit sourceTransformerTestKit =
+                new SourceTransformerTestKit(new EventTimeFilterFunction());
+        try {
+            sourceTransformerTestKit.startServer();
+        } catch (Exception e) {
+            Assertions.fail("Failed to start server");
+        }
+
+        // Create a client which can send requests to the server
+        SourceTransformerTestKit.Client client = new SourceTransformerTestKit.Client();
+
+        SourceTransformerTestKit.TestDatum datum =
+                SourceTransformerTestKit.TestDatum.builder()
+                        .eventTime(Instant.ofEpochMilli(1640995200000L))
+                        .value("test".getBytes())
+                        .build();
+        io.numaproj.numaflow.sourcetransformer.MessageList result =
+                client.sendRequest(new String[]{}, datum);
+
+        List<io.numaproj.numaflow.sourcetransformer.Message> messages = result.getMessages();
+        Assertions.assertEquals(1, messages.size());
+
+        Assertions.assertEquals("test", new String(messages.get(0).getValue()));
+        Assertions.assertEquals("within_year_2022", messages.get(0).getTags()[0]);
+
+        try {
+            client.close();
+            sourceTransformerTestKit.stopServer();
+        } catch (Exception e) {
+            Assertions.fail("Failed to stop server");
+        }
     }
-  }
-
-  @Test
-  @Order(4)
-  public void testSinkServerInvocation() {
-    int datumCount = 10;
-    SinkerTestKit sinkerTestKit = new SinkerTestKit(new SimpleSink());
-
-    // Start the server
-    try {
-      sinkerTestKit.startServer();
-    } catch (Exception e) {
-      Assertions.fail("Failed to start server");
-    }
-
-    // Create a test datum iterator with 10 messages
-    SinkerTestKit.TestListIterator testListIterator = new SinkerTestKit.TestListIterator();
-    for (int i = 0; i < datumCount; i++) {
-      testListIterator.addDatum(
-          SinkerTestKit.TestDatum.builder()
-              .id("id-" + i)
-              .value(("value-" + i).getBytes())
-              .headers(Map.of("test-key", "test-value"))
-              .build());
-    }
-
-    SinkerTestKit.Client client = new SinkerTestKit.Client();
-    try {
-      ResponseList responseList = client.sendRequest(testListIterator);
-      Assertions.assertEquals(datumCount, responseList.getResponses().size());
-      for (Response response : responseList.getResponses()) {
-        Assertions.assertEquals(true, response.getSuccess());
-      }
-    } catch (Exception e) {
-      Assertions.fail("Failed to send requests");
-    }
-
-    // Stop the server
-    try {
-      client.close();
-      sinkerTestKit.stopServer();
-    } catch (InterruptedException e) {
-      Assertions.fail("Failed to stop server");
-    }
-
-    // we can add the logic to verify if the messages were
-    // successfully written to the sink(could be a file, database, etc.)
-  }
-
-  // FIXME: once tester kit changes are done for bidirectional streaming source
-  //    @Ignore
-  //    @Test
-  //    @Order(5)
-  //    public void testSourceServerInvocation() {
-  //        SimpleSource simpleSource = new SimpleSource();
-  //
-  //        SourcerTestKit sourcerTestKit = new SourcerTestKit(simpleSource);
-  //        try {
-  //            sourcerTestKit.startServer();
-  //        } catch (Exception e) {
-  //            Assertions.fail("Failed to start server");
-  //        }
-  //
-  //        // create a client to send requests to the server
-  //        SourcerTestKit.Client sourcerClient = new SourcerTestKit.Client();
-  //        // create a test observer to receive messages from the server
-  //        SourcerTestKit.TestListBasedObserver testObserver = new
-  // SourcerTestKit.TestListBasedObserver();
-  //        // create a read request with count 10 and timeout 1 second
-  //        SourcerTestKit.TestReadRequest testReadRequest =
-  // SourcerTestKit.TestReadRequest.builder()
-  //                .count(10).timeout(Duration.ofSeconds(1)).build();
-  //
-  //        try {
-  //            sourcerClient.sendReadRequest(testReadRequest, testObserver);
-  //            Assertions.assertEquals(10, testObserver.getMessages().size());
-  //        } catch (Exception e) {
-  //            Assertions.fail("Failed to send request to server");
-  //        }
-  //
-  //        try {
-  //            sourcerClient.close();
-  //            sourcerTestKit.stopServer();
-  //        } catch (InterruptedException e) {
-  //            Assertions.fail("Failed to stop server");
-  //        }
-  //    }
-
-  @Test
-  @Order(6)
-  public void testSourceTransformerServerInvocation() {
-    SourceTransformerTestKit sourceTransformerTestKit =
-        new SourceTransformerTestKit(new EventTimeFilterFunction());
-    try {
-      sourceTransformerTestKit.startServer();
-    } catch (Exception e) {
-      Assertions.fail("Failed to start server");
-    }
-
-    // Create a client which can send requests to the server
-    SourceTransformerTestKit.Client client = new SourceTransformerTestKit.Client();
-
-    SourceTransformerTestKit.TestDatum datum =
-        SourceTransformerTestKit.TestDatum.builder()
-            .eventTime(Instant.ofEpochMilli(1640995200000L))
-            .value("test".getBytes())
-            .build();
-    io.numaproj.numaflow.sourcetransformer.MessageList result =
-        client.sendRequest(new String[] {}, datum);
-
-    List<io.numaproj.numaflow.sourcetransformer.Message> messages = result.getMessages();
-    Assertions.assertEquals(1, messages.size());
-
-    Assertions.assertEquals("test", new String(messages.get(0).getValue()));
-    Assertions.assertEquals("within_year_2022", messages.get(0).getTags()[0]);
-
-    try {
-      client.close();
-      sourceTransformerTestKit.stopServer();
-    } catch (Exception e) {
-      Assertions.fail("Failed to stop server");
-    }
-  }
 }

--- a/examples/src/test/java/io/numaproj/numaflow/examples/server/ServerTest.java
+++ b/examples/src/test/java/io/numaproj/numaflow/examples/server/ServerTest.java
@@ -29,7 +29,6 @@ import java.util.Map;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @Slf4j
 public class ServerTest {
-
     @Test
     @Order(1)
     public void testMapServerInvocation() {

--- a/examples/src/test/java/io/numaproj/numaflow/examples/server/ServerTest.java
+++ b/examples/src/test/java/io/numaproj/numaflow/examples/server/ServerTest.java
@@ -14,17 +14,16 @@ import io.numaproj.numaflow.sinker.Response;
 import io.numaproj.numaflow.sinker.ResponseList;
 import io.numaproj.numaflow.sinker.SinkerTestKit;
 import io.numaproj.numaflow.sourcetransformer.SourceTransformerTestKit;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @Slf4j
@@ -182,7 +181,7 @@ public class ServerTest {
             ResponseList responseList = client.sendRequest(testListIterator);
             Assertions.assertEquals(datumCount, responseList.getResponses().size());
             for (Response response : responseList.getResponses()) {
-                Assertions.assertEquals(true, response.getSuccess());
+                Assertions.assertEquals(true, response.isSuccess());
             }
         } catch (Exception e) {
             Assertions.fail("Failed to send requests");

--- a/examples/src/test/java/io/numaproj/numaflow/examples/sink/simple/SimpleSinkTest.java
+++ b/examples/src/test/java/io/numaproj/numaflow/examples/sink/simple/SimpleSinkTest.java
@@ -10,24 +10,27 @@ import org.junit.jupiter.api.Test;
 @Slf4j
 public class SimpleSinkTest {
 
-  @Test
-  public void testSimpleSink() {
-    int datumCount = 10;
-    SimpleSink simpleSink = new SimpleSink();
+    @Test
+    public void testSimpleSink() {
+        int datumCount = 10;
+        SimpleSink simpleSink = new SimpleSink();
 
-    // Create a test datum iterator with 10 messages
-    SinkerTestKit.TestListIterator testListIterator = new SinkerTestKit.TestListIterator();
-    for (int i = 0; i < datumCount; i++) {
-      testListIterator.addDatum(
-          SinkerTestKit.TestDatum.builder().id("id-" + i).value(("value-" + i).getBytes()).build());
-    }
+        // Create a test datum iterator with 10 messages
+        SinkerTestKit.TestListIterator testListIterator = new SinkerTestKit.TestListIterator();
+        for (int i = 0; i < datumCount; i++) {
+            testListIterator.addDatum(SinkerTestKit.TestDatum
+                    .builder()
+                    .id("id-" + i)
+                    .value(("value-" + i).getBytes())
+                    .build());
+        }
 
-    ResponseList responseList = simpleSink.processMessages(testListIterator);
-    Assertions.assertEquals(datumCount, responseList.getResponses().size());
-    for (Response response : responseList.getResponses()) {
-      Assertions.assertEquals(true, response.Success());
+        ResponseList responseList = simpleSink.processMessages(testListIterator);
+        Assertions.assertEquals(datumCount, responseList.getResponses().size());
+        for (Response response : responseList.getResponses()) {
+            Assertions.assertEquals(true, response.isSuccess());
+        }
+        // we can add the logic to verify if the messages were
+        // successfully written to the sink(could be a file, database, etc.)
     }
-    // we can add the logic to verify if the messages were
-    // successfully written to the sink(could be a file, database, etc.)
-  }
 }

--- a/examples/src/test/java/io/numaproj/numaflow/examples/sink/simple/SimpleSinkTest.java
+++ b/examples/src/test/java/io/numaproj/numaflow/examples/sink/simple/SimpleSinkTest.java
@@ -7,7 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-
 @Slf4j
 public class SimpleSinkTest {
 
@@ -29,7 +28,7 @@ public class SimpleSinkTest {
         ResponseList responseList = simpleSink.processMessages(testListIterator);
         Assertions.assertEquals(datumCount, responseList.getResponses().size());
         for (Response response : responseList.getResponses()) {
-            Assertions.assertEquals(true, response.getSuccess());
+            Assertions.assertEquals(true, response.isSuccess());
         }
         // we can add the logic to verify if the messages were
         // successfully written to the sink(could be a file, database, etc.)

--- a/examples/src/test/java/io/numaproj/numaflow/examples/sink/simple/SimpleSinkTest.java
+++ b/examples/src/test/java/io/numaproj/numaflow/examples/sink/simple/SimpleSinkTest.java
@@ -14,7 +14,6 @@ public class SimpleSinkTest {
   public void testSimpleSink() {
     int datumCount = 10;
     SimpleSink simpleSink = new SimpleSink();
-
     // Create a test datum iterator with 10 messages
     SinkerTestKit.TestListIterator testListIterator = new SinkerTestKit.TestListIterator();
     for (int i = 0; i < datumCount; i++) {

--- a/examples/src/test/java/io/numaproj/numaflow/examples/sink/simple/SimpleSinkTest.java
+++ b/examples/src/test/java/io/numaproj/numaflow/examples/sink/simple/SimpleSinkTest.java
@@ -10,27 +10,24 @@ import org.junit.jupiter.api.Test;
 @Slf4j
 public class SimpleSinkTest {
 
-    @Test
-    public void testSimpleSink() {
-        int datumCount = 10;
-        SimpleSink simpleSink = new SimpleSink();
+  @Test
+  public void testSimpleSink() {
+    int datumCount = 10;
+    SimpleSink simpleSink = new SimpleSink();
 
-        // Create a test datum iterator with 10 messages
-        SinkerTestKit.TestListIterator testListIterator = new SinkerTestKit.TestListIterator();
-        for (int i = 0; i < datumCount; i++) {
-            testListIterator.addDatum(SinkerTestKit.TestDatum
-                    .builder()
-                    .id("id-" + i)
-                    .value(("value-" + i).getBytes())
-                    .build());
-        }
-
-        ResponseList responseList = simpleSink.processMessages(testListIterator);
-        Assertions.assertEquals(datumCount, responseList.getResponses().size());
-        for (Response response : responseList.getResponses()) {
-            Assertions.assertEquals(true, response.isSuccess());
-        }
-        // we can add the logic to verify if the messages were
-        // successfully written to the sink(could be a file, database, etc.)
+    // Create a test datum iterator with 10 messages
+    SinkerTestKit.TestListIterator testListIterator = new SinkerTestKit.TestListIterator();
+    for (int i = 0; i < datumCount; i++) {
+      testListIterator.addDatum(
+          SinkerTestKit.TestDatum.builder().id("id-" + i).value(("value-" + i).getBytes()).build());
     }
+
+    ResponseList responseList = simpleSink.processMessages(testListIterator);
+    Assertions.assertEquals(datumCount, responseList.getResponses().size());
+    for (Response response : responseList.getResponses()) {
+      Assertions.assertEquals(true, response.getSuccess());
+    }
+    // we can add the logic to verify if the messages were
+    // successfully written to the sink(could be a file, database, etc.)
+  }
 }

--- a/examples/src/test/java/io/numaproj/numaflow/examples/sink/simple/SimpleSinkTest.java
+++ b/examples/src/test/java/io/numaproj/numaflow/examples/sink/simple/SimpleSinkTest.java
@@ -10,27 +10,24 @@ import org.junit.jupiter.api.Test;
 @Slf4j
 public class SimpleSinkTest {
 
-    @Test
-    public void testSimpleSink() {
-        int datumCount = 10;
-        SimpleSink simpleSink = new SimpleSink();
+  @Test
+  public void testSimpleSink() {
+    int datumCount = 10;
+    SimpleSink simpleSink = new SimpleSink();
 
-        // Create a test datum iterator with 10 messages
-        SinkerTestKit.TestListIterator testListIterator = new SinkerTestKit.TestListIterator();
-        for (int i = 0; i < datumCount; i++) {
-            testListIterator.addDatum(SinkerTestKit.TestDatum
-                    .builder()
-                    .id("id-" + i)
-                    .value(("value-" + i).getBytes())
-                    .build());
-        }
-
-        ResponseList responseList = simpleSink.processMessages(testListIterator);
-        Assertions.assertEquals(datumCount, responseList.getResponses().size());
-        for (Response response : responseList.getResponses()) {
-            Assertions.assertEquals(true, response.isSuccess());
-        }
-        // we can add the logic to verify if the messages were
-        // successfully written to the sink(could be a file, database, etc.)
+    // Create a test datum iterator with 10 messages
+    SinkerTestKit.TestListIterator testListIterator = new SinkerTestKit.TestListIterator();
+    for (int i = 0; i < datumCount; i++) {
+      testListIterator.addDatum(
+          SinkerTestKit.TestDatum.builder().id("id-" + i).value(("value-" + i).getBytes()).build());
     }
+
+    ResponseList responseList = simpleSink.processMessages(testListIterator);
+    Assertions.assertEquals(datumCount, responseList.getResponses().size());
+    for (Response response : responseList.getResponses()) {
+      Assertions.assertEquals(true, response.Success());
+    }
+    // we can add the logic to verify if the messages were
+    // successfully written to the sink(could be a file, database, etc.)
+  }
 }

--- a/examples/src/test/java/io/numaproj/numaflow/examples/sink/simple/SimpleSinkTest.java
+++ b/examples/src/test/java/io/numaproj/numaflow/examples/sink/simple/SimpleSinkTest.java
@@ -10,23 +10,26 @@ import org.junit.jupiter.api.Test;
 @Slf4j
 public class SimpleSinkTest {
 
-  @Test
-  public void testSimpleSink() {
-    int datumCount = 10;
-    SimpleSink simpleSink = new SimpleSink();
-    // Create a test datum iterator with 10 messages
-    SinkerTestKit.TestListIterator testListIterator = new SinkerTestKit.TestListIterator();
-    for (int i = 0; i < datumCount; i++) {
-      testListIterator.addDatum(
-          SinkerTestKit.TestDatum.builder().id("id-" + i).value(("value-" + i).getBytes()).build());
+    @Test
+    public void testSimpleSink() {
+        int datumCount = 10;
+        SimpleSink simpleSink = new SimpleSink();
+        // Create a test datum iterator with 10 messages
+        SinkerTestKit.TestListIterator testListIterator = new SinkerTestKit.TestListIterator();
+        for (int i = 0; i < datumCount; i++) {
+            testListIterator.addDatum(
+                    SinkerTestKit.TestDatum
+                            .builder()
+                            .id("id-" + i)
+                            .value(("value-" + i).getBytes())
+                            .build());
+        }
+        ResponseList responseList = simpleSink.processMessages(testListIterator);
+        Assertions.assertEquals(datumCount, responseList.getResponses().size());
+        for (Response response : responseList.getResponses()) {
+            Assertions.assertEquals(true, response.getSuccess());
+        }
+        // we can add the logic to verify if the messages were
+        // successfully written to the sink(could be a file, database, etc.)
     }
-
-    ResponseList responseList = simpleSink.processMessages(testListIterator);
-    Assertions.assertEquals(datumCount, responseList.getResponses().size());
-    for (Response response : responseList.getResponses()) {
-      Assertions.assertEquals(true, response.getSuccess());
-    }
-    // we can add the logic to verify if the messages were
-    // successfully written to the sink(could be a file, database, etc.)
-  }
 }

--- a/src/main/java/io/numaproj/numaflow/sinker/Response.java
+++ b/src/main/java/io/numaproj/numaflow/sinker/Response.java
@@ -13,9 +13,9 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Response {
   private final String id;
-  private final boolean success;
+  private final Boolean success;
   private final String err;
-  private final boolean fallback;
+  private final Boolean fallback;
 
   /**
    * Static method to create response for successful message processing.

--- a/src/main/java/io/numaproj/numaflow/sinker/Service.java
+++ b/src/main/java/io/numaproj/numaflow/sinker/Service.java
@@ -10,15 +10,14 @@ import io.grpc.stub.StreamObserver;
 import io.numaproj.numaflow.shared.ExceptionUtils;
 import io.numaproj.numaflow.sink.v1.SinkGrpc;
 import io.numaproj.numaflow.sink.v1.SinkOuterClass;
-import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @AllArgsConstructor
@@ -139,8 +138,8 @@ class Service extends SinkGrpc.SinkImplBase {
     }
 
     private SinkOuterClass.SinkResponse.Result buildResult(Response response) {
-        SinkOuterClass.Status status = response.isFallback() ? SinkOuterClass.Status.FALLBACK
-                : response.isSuccess() ? SinkOuterClass.Status.SUCCESS : SinkOuterClass.Status.FAILURE;
+        SinkOuterClass.Status status = response.getFallback() ? SinkOuterClass.Status.FALLBACK
+                : response.getSuccess() ? SinkOuterClass.Status.SUCCESS : SinkOuterClass.Status.FAILURE;
         return SinkOuterClass.SinkResponse.Result.newBuilder()
                 .setId(response.getId() == null ? "" : response.getId())
                 .setErrMsg(response.getErr() == null ? "" : response.getErr())


### PR DESCRIPTION
1. A recent change update the Response Getter function from `getSuccess()` to `isSuccess`. An example was broken because of that.

```
/home/runner/work/numaflow-java/numaflow-java/examples/src/test/java/io/numaproj/numaflow/examples/sink/simple/SimpleSinkTest.java:[32,51] cannot find symbol
Error:    symbol:   method getSuccess()
Error:    location: variable response of type io.numaproj.numaflow.sinker.Response
```

Issue was detected late during the example image build push. This code change adds the building of examples to the CI so that if an SDK change breaks any examples, the issue can be caught during CI instead of after merging.

2. This makes me realize the change of sinker `success` from `Boolean` to `boolean` is backward-incompatible to users, who use the getter in udsink. I scanned Intuit repo and saw we do have existing users using the getter. I am reverting the `Boolean to boolean` change for now to ensure backward compatiblitity.

