### PR TITLE
fix: remove onCompleted() call in batch mapper service

### DIFF
--- a/src/main/java/io/numaproj/numaflow/batchmapper/Service.java
+++ b/src/main/java/io/numaproj/numaflow/batchmapper/Service.java
@@ -171,7 +171,6 @@ class Service extends MapGrpc.MapImplBase {
                 .setStatus(MapOuterClass.TransmissionStatus.newBuilder().setEot(true).build())
                 .build();
         responseObserver.onNext(eotResponse);
-        responseObserver.onCompleted();
     }
 
     // IsReady is the heartbeat endpoint for gRPC.


### PR DESCRIPTION
Identified the bug while running e2e tests. Only first message was being honoured, and the stream didn't accept any further messages.