### PR TITLE
fix: handle cancelled gRPC streams in supervisors

### DIFF
--- a/src/main/java/io/numaproj/numaflow/mapper/MapSupervisorActor.java
+++ b/src/main/java/io/numaproj/numaflow/mapper/MapSupervisorActor.java
@@ -9,17 +9,16 @@ import akka.actor.SupervisorStrategy;
 import akka.japi.pf.DeciderBuilder;
 import akka.japi.pf.ReceiveBuilder;
 import io.grpc.Status;
-import com.google.protobuf.Any;
-import com.google.rpc.Code;
-import com.google.rpc.DebugInfo;
 import io.grpc.protobuf.StatusProto;
 import io.grpc.stub.StreamObserver;
 import io.numaproj.numaflow.map.v1.MapOuterClass;
 import io.numaproj.numaflow.shared.ExceptionUtils;
+import io.numaproj.numaflow.shared.InputStreamError;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * MapSupervisorActor actor is responsible for distributing the messages to actors and handling failure.
@@ -52,6 +51,8 @@ class MapSupervisorActor extends AbstractActor {
     private final Mapper mapper;
     private final StreamObserver<MapOuterClass.MapResponse> responseObserver;
     private final CompletableFuture<Void> shutdownSignal;
+    private final AtomicBoolean streamClosed = new AtomicBoolean(false);
+    private boolean inputCompleted;
     private int activeMapperCount;
     private Exception userException;
 
@@ -62,6 +63,7 @@ class MapSupervisorActor extends AbstractActor {
         this.mapper = mapper;
         this.responseObserver = responseObserver;
         this.shutdownSignal = failureFuture;
+        this.inputCompleted = false;
         this.userException = null;
         this.activeMapperCount = 0;
     }
@@ -79,8 +81,7 @@ class MapSupervisorActor extends AbstractActor {
                 .getSystem()
                 .log()
                 .warning("supervisor pre restart was executed due to: {}", reason.getMessage());
-        shutdownSignal.completeExceptionally(reason);
-        responseObserver.onError(Status.INTERNAL
+        sendError(Status.INTERNAL
                 .withDescription(reason.getMessage())
                 .withCause(reason)
                 .asException());
@@ -99,9 +100,10 @@ class MapSupervisorActor extends AbstractActor {
                 .create()
                 .match(MapOuterClass.MapRequest.class, this::processRequest)
                 .match(MapOuterClass.MapResponse.class, this::sendResponse)
+                .match(InputStreamError.class, this::handleInputStreamError)
                 .match(Exception.class, this::handleFailure)
                 .match(AllDeadLetters.class, this::handleDeadLetters)
-                .match(String.class, eof -> responseObserver.onCompleted())
+                .match(String.class, eof -> handleInputCompleted())
                 .build();
     }
 
@@ -113,25 +115,28 @@ class MapSupervisorActor extends AbstractActor {
             // one exception should trigger a container restart
             // Build gRPC Status
             com.google.rpc.Status status = ExceptionUtils.buildStatusFromUserException(e);
-            responseObserver.onError(StatusProto.toStatusRuntimeException(status));
+            sendError(StatusProto.toStatusRuntimeException(status));
         }
         activeMapperCount--;
+        finishIfDrained();
     }
 
     private void sendResponse(MapOuterClass.MapResponse mapResponse) {
-        responseObserver.onNext(mapResponse);
-        activeMapperCount--;
+        try {
+            if (!streamClosed.get()) {
+                responseObserver.onNext(mapResponse);
+            }
+        } catch (RuntimeException e) {
+            handleResponseObserverFailure(e);
+        } finally {
+            activeMapperCount--;
+            finishIfDrained();
+        }
     }
 
     private void processRequest(MapOuterClass.MapRequest mapRequest) {
         if (userException != null) {
             log.info("a previous mapper actor failed, not processing any more requests");
-            if (activeMapperCount == 0) {
-                log.info("there is no more active mapper AKKA actors - stopping the system");
-                getContext().getSystem().stop(getSelf());
-                log.info("AKKA system stopped");
-                shutdownSignal.completeExceptionally(userException);
-            }
             return;
         }
 
@@ -145,13 +150,70 @@ class MapSupervisorActor extends AbstractActor {
         activeMapperCount++;
     }
 
+    private void handleInputStreamError(InputStreamError error) {
+        log.error("inbound request stream error, stopping mapper supervisor", error.getCause());
+        streamClosed.set(true);
+        getContext().getSystem().stop(getSelf());
+        shutdownSignal.completeExceptionally(error.getCause());
+    }
+
     // if we see dead letters, we need to stop the execution and exit
     // to make sure no messages are lost
     private void handleDeadLetters(AllDeadLetters deadLetter) {
         log.error("got a dead letter, stopping the execution");
-        responseObserver.onError(Status.INTERNAL.withDescription("dead letters").asException());
+        sendError(Status.INTERNAL.withDescription("dead letters").asException());
         getContext().getSystem().stop(getSelf());
         shutdownSignal.completeExceptionally(new Throwable("dead letters"));
+    }
+
+    private void handleInputCompleted() {
+        inputCompleted = true;
+        finishIfDrained();
+    }
+
+    // EOF and failures can arrive while child actors are still processing.
+    // Only finish the stream once all started child actors have replied or failed.
+    private void finishIfDrained() {
+        if (activeMapperCount != 0) {
+            return;
+        }
+        if (userException != null) {
+            getContext().getSystem().stop(getSelf());
+            shutdownSignal.completeExceptionally(userException);
+            return;
+        }
+        if (inputCompleted) {
+            completeResponse();
+        }
+    }
+
+    private void completeResponse() {
+        if (streamClosed.compareAndSet(false, true)) {
+            try {
+                responseObserver.onCompleted();
+            } catch (RuntimeException e) {
+                handleResponseObserverFailure(e);
+            } finally {
+                getContext().getSystem().stop(getSelf());
+            }
+        }
+    }
+
+    private void sendError(Throwable throwable) {
+        if (streamClosed.compareAndSet(false, true)) {
+            try {
+                responseObserver.onError(throwable);
+            } catch (RuntimeException e) {
+                handleResponseObserverFailure(e);
+            }
+        }
+    }
+
+    private void handleResponseObserverFailure(RuntimeException e) {
+        log.warn("response stream is already closed; stopping mapper supervisor", e);
+        streamClosed.set(true);
+        getContext().getSystem().stop(getSelf());
+        shutdownSignal.completeExceptionally(e);
     }
 
     @Override
@@ -160,11 +222,11 @@ class MapSupervisorActor extends AbstractActor {
         return new AllForOneStrategy(
                 DeciderBuilder
                         .match(Exception.class, e -> {
-                            shutdownSignal.completeExceptionally(e);
-                            responseObserver.onError(Status.INTERNAL
+                            sendError(Status.INTERNAL
                                     .withDescription(e.getMessage())
                                     .withCause(e)
                                     .asException());
+                            shutdownSignal.completeExceptionally(e);
                             return SupervisorStrategy.stop();
                         })
                         .build()

--- a/src/main/java/io/numaproj/numaflow/mapper/Server.java
+++ b/src/main/java/io/numaproj/numaflow/mapper/Server.java
@@ -23,6 +23,7 @@ public class Server {
     private final CompletableFuture<Void> shutdownSignal;
     private final ServerInfoAccessor serverInfoAccessor = new ServerInfoAccessorImpl(new ObjectMapper());
     private final GrpcServerWrapper server;
+    private final boolean exitOnFailure;
 
     /**
      * constructor to create gRPC server.
@@ -43,6 +44,7 @@ public class Server {
         this.shutdownSignal = new CompletableFuture<>();
         this.grpcConfig = grpcConfig;
         this.server = new GrpcServerWrapper(this.grpcConfig, new Service(mapper, this.shutdownSignal));
+        this.exitOnFailure = true;
     }
 
     @VisibleForTesting
@@ -53,6 +55,7 @@ public class Server {
                 interceptor,
                 serverName,
                 new Service(service, this.shutdownSignal));
+        this.exitOnFailure = false;
     }
 
     /**
@@ -102,7 +105,9 @@ public class Server {
                     this.stop();
                     // FIXME - this is a workaround to immediately terminate the JVM process
                     // The correct way to do this is to stop all the actors and wait for them to terminate
-                    System.exit(0);
+                    if (exitOnFailure) {
+                        System.exit(0);
+                    }
                 } catch (InterruptedException ex) {
                     Thread.interrupted();
                     ex.printStackTrace(System.err);

--- a/src/main/java/io/numaproj/numaflow/mapper/Service.java
+++ b/src/main/java/io/numaproj/numaflow/mapper/Service.java
@@ -7,6 +7,7 @@ import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import io.numaproj.numaflow.map.v1.MapGrpc;
 import io.numaproj.numaflow.map.v1.MapOuterClass;
+import io.numaproj.numaflow.shared.InputStreamError;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -62,7 +63,7 @@ class Service extends MapGrpc.MapImplBase {
 
             @Override
             public void onError(Throwable throwable) {
-                mapSupervisorActor.tell(new Exception(throwable), ActorRef.noSender());
+                mapSupervisorActor.tell(new InputStreamError(throwable), ActorRef.noSender());
             }
 
             @Override

--- a/src/main/java/io/numaproj/numaflow/mapstreamer/Constants.java
+++ b/src/main/java/io/numaproj/numaflow/mapstreamer/Constants.java
@@ -8,6 +8,7 @@ class Constants {
   public static final String DEFAULT_HOST = "localhost";
   public static final String MAP_MODE_KEY = "MAP_MODE";
   public static final String MAP_MODE = "stream-map";
+  public static final String EOF = "EOF";
 
   // Private constructor to prevent instantiation
   private Constants() {

--- a/src/main/java/io/numaproj/numaflow/mapstreamer/MapStreamSupervisorActor.java
+++ b/src/main/java/io/numaproj/numaflow/mapstreamer/MapStreamSupervisorActor.java
@@ -145,6 +145,9 @@ class MapStreamSupervisorActor extends AbstractActor {
         } catch (RuntimeException e) {
             handleResponseObserverFailure(e);
         } finally {
+            if (!mapResponse.hasStatus() || !mapResponse.getStatus().getEot()) {
+                return;
+            }
             activeMapStreamersCount--;
             finishIfDrained();
         }

--- a/src/main/java/io/numaproj/numaflow/mapstreamer/MapStreamSupervisorActor.java
+++ b/src/main/java/io/numaproj/numaflow/mapstreamer/MapStreamSupervisorActor.java
@@ -12,10 +12,12 @@ import io.grpc.protobuf.StatusProto;
 import io.grpc.stub.StreamObserver;
 import io.numaproj.numaflow.map.v1.MapOuterClass;
 import io.numaproj.numaflow.shared.ExceptionUtils;
+import io.numaproj.numaflow.shared.InputStreamError;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * MapStreamSupervisorActor is responsible for managing MapStreamerActor instances and handling failures.
@@ -51,6 +53,8 @@ class MapStreamSupervisorActor extends AbstractActor {
     private final MapStreamer mapStreamer;
     private final StreamObserver<MapOuterClass.MapResponse> responseObserver;
     private final CompletableFuture<Void> shutdownSignal;
+    private final AtomicBoolean streamClosed = new AtomicBoolean(false);
+    private boolean inputCompleted;
     private int activeMapStreamersCount;
     private Exception userException;
 
@@ -61,6 +65,7 @@ class MapStreamSupervisorActor extends AbstractActor {
         this.mapStreamer = mapStreamer;
         this.responseObserver = responseObserver;
         this.shutdownSignal = failureFuture;
+        this.inputCompleted = false;
         this.userException = null;
         this.activeMapStreamersCount = 0;
     }
@@ -80,18 +85,26 @@ class MapStreamSupervisorActor extends AbstractActor {
                 .getSystem()
                 .log()
                 .warning("supervisor pre restart due to: {}", reason.getMessage());
-        shutdownSignal.completeExceptionally(reason);
-        responseObserver.onError(Status.INTERNAL
+        sendError(Status.INTERNAL
                 .withDescription(reason.getMessage())
                 .withCause(reason)
                 .asException());
+        getContext().getSystem().stop(getSelf());
+        shutdownSignal.completeExceptionally(reason);
+    }
+
+    private void handleInputStreamError(InputStreamError error) {
+        log.error("inbound request stream error, stopping map-stream supervisor", error.getCause());
+        streamClosed.set(true);
+        getContext().getSystem().stop(getSelf());
+        shutdownSignal.completeExceptionally(error.getCause());
     }
 
     // if we see dead letters, we need to stop the execution and exit
     // to make sure no messages are lost
     private void handleDeadLetters(AllDeadLetters deadLetter) {
         log.error("got a dead letter, stopping the execution");
-        responseObserver.onError(Status.INTERNAL.withDescription("dead letters").asException());
+        sendError(Status.INTERNAL.withDescription("dead letters").asException());
         getContext().getSystem().stop(getSelf());
         shutdownSignal.completeExceptionally(new Throwable("dead letters"));
     }
@@ -106,8 +119,10 @@ class MapStreamSupervisorActor extends AbstractActor {
         return receiveBuilder()
                 .match(MapOuterClass.MapRequest.class, this::processRequest)
                 .match(MapOuterClass.MapResponse.class, this::sendResponse)
+                .match(InputStreamError.class, this::handleInputStreamError)
                 .match(Exception.class, this::handleFailure)
                 .match(AllDeadLetters.class, this::handleDeadLetters)
+                .match(String.class, eof -> handleInputCompleted())
                 .build();
     }
 
@@ -116,27 +131,28 @@ class MapStreamSupervisorActor extends AbstractActor {
         if (userException == null) {
             userException = e;
             com.google.rpc.Status status = ExceptionUtils.buildStatusFromUserException(e);
-            responseObserver.onError(StatusProto.toStatusRuntimeException(status));
+            sendError(StatusProto.toStatusRuntimeException(status));
         }
         activeMapStreamersCount--;
+        finishIfDrained();
     }
 
     private void sendResponse(MapOuterClass.MapResponse mapResponse) {
-        responseObserver.onNext(mapResponse);
-        activeMapStreamersCount--;
+        try {
+            if (!streamClosed.get()) {
+                responseObserver.onNext(mapResponse);
+            }
+        } catch (RuntimeException e) {
+            handleResponseObserverFailure(e);
+        } finally {
+            activeMapStreamersCount--;
+            finishIfDrained();
+        }
     }
 
     private void processRequest(MapOuterClass.MapRequest mapRequest) {
         if (userException != null) {
-            getContext()
-                    .getSystem()
-                    .log()
-                    .info("Previous mapStreamer actor failed, not processing further requests");
-            if (activeMapStreamersCount == 0) {
-                getContext().getSystem().log().info("No active mapStreamer actors, shutting down");
-                getContext().getSystem().terminate();
-                shutdownSignal.completeExceptionally(userException);
-            }
+            getContext().getSystem().log().info("Previous mapStreamer actor failed, not processing further requests");
             return;
         }
 
@@ -150,14 +166,64 @@ class MapStreamSupervisorActor extends AbstractActor {
     public SupervisorStrategy supervisorStrategy() {
         return new AllForOneStrategy(
                 DeciderBuilder.match(Exception.class, e -> {
-                    shutdownSignal.completeExceptionally(e);
-                    responseObserver.onError(Status.INTERNAL
+                    sendError(Status.INTERNAL
                             .withDescription(e.getMessage())
                             .withCause(e)
                             .asException());
+                    shutdownSignal.completeExceptionally(e);
                     return SupervisorStrategy.stop();
                 }).build()
         );
+    }
+
+    private void handleInputCompleted() {
+        inputCompleted = true;
+        finishIfDrained();
+    }
+
+    // EOF and failures can arrive while child actors are still processing.
+    // Only finish the stream once all started child actors have replied or failed.
+    private void finishIfDrained() {
+        if (activeMapStreamersCount != 0) {
+            return;
+        }
+        if (userException != null) {
+            getContext().getSystem().stop(getSelf());
+            shutdownSignal.completeExceptionally(userException);
+            return;
+        }
+        if (inputCompleted) {
+            completeResponse();
+        }
+    }
+
+    private void completeResponse() {
+        if (streamClosed.compareAndSet(false, true)) {
+            try {
+                responseObserver.onCompleted();
+            } catch (RuntimeException e) {
+                handleResponseObserverFailure(e);
+            } finally {
+                getContext().getSystem().stop(getSelf());
+            }
+        }
+    }
+
+    private void sendError(Throwable throwable) {
+        if (streamClosed.compareAndSet(false, true)) {
+            try {
+                responseObserver.onError(throwable);
+            } catch (RuntimeException e) {
+                handleResponseObserverFailure(e);
+            }
+        }
+    }
+
+    private void handleResponseObserverFailure(RuntimeException e) {
+        log.warn("response stream is already closed; stopping map-stream supervisor", e);
+        streamClosed.set(true);
+        getContext().getSystem().stop(getSelf());
+        shutdownSignal.completeExceptionally(e);
     }
 }
 

--- a/src/main/java/io/numaproj/numaflow/mapstreamer/Service.java
+++ b/src/main/java/io/numaproj/numaflow/mapstreamer/Service.java
@@ -7,6 +7,7 @@ import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import io.numaproj.numaflow.map.v1.MapGrpc;
 import io.numaproj.numaflow.map.v1.MapOuterClass;
+import io.numaproj.numaflow.shared.InputStreamError;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -61,12 +62,12 @@ class Service extends MapGrpc.MapImplBase {
 
             @Override
             public void onError(Throwable throwable) {
-                mapStreamSupervisorActor.tell(new Exception(throwable), ActorRef.noSender());
+                mapStreamSupervisorActor.tell(new InputStreamError(throwable), ActorRef.noSender());
             }
 
             @Override
             public void onCompleted() {
-                responseObserver.onCompleted();
+                mapStreamSupervisorActor.tell(Constants.EOF, ActorRef.noSender());
             }
         };
     }

--- a/src/main/java/io/numaproj/numaflow/shared/InputStreamError.java
+++ b/src/main/java/io/numaproj/numaflow/shared/InputStreamError.java
@@ -1,0 +1,16 @@
+package io.numaproj.numaflow.shared;
+
+/**
+ * Message sent by gRPC services to supervisor actors when the inbound request stream fails.
+ */
+public class InputStreamError {
+    private final Throwable cause;
+
+    public InputStreamError(Throwable cause) {
+        this.cause = cause;
+    }
+
+    public Throwable getCause() {
+        return cause;
+    }
+}

--- a/src/main/java/io/numaproj/numaflow/sourcetransformer/Server.java
+++ b/src/main/java/io/numaproj/numaflow/sourcetransformer/Server.java
@@ -22,6 +22,7 @@ public class Server {
     private final CompletableFuture<Void> shutdownSignal;
     private final ServerInfoAccessor serverInfoAccessor = new ServerInfoAccessorImpl(new ObjectMapper());
     private final GrpcServerWrapper server;
+    private final boolean exitOnFailure;
 
     /**
      * constructor to create gRPC server.
@@ -42,6 +43,7 @@ public class Server {
         this.shutdownSignal = new CompletableFuture<>();
         this.grpcConfig = grpcConfig;
         this.server = new GrpcServerWrapper(this.grpcConfig, new Service(sourceTransformer, this.shutdownSignal));
+        this.exitOnFailure = true;
     }
 
     @VisibleForTesting
@@ -52,6 +54,7 @@ public class Server {
                 interceptor,
                 serverName,
                 new Service(service, this.shutdownSignal));
+        this.exitOnFailure = false;
     }
 
     /**
@@ -98,7 +101,9 @@ public class Server {
                     this.stop();
                     // FIXME - this is a workaround to immediately terminate the JVM process
                     // The correct way to do this is to stop all the actors and wait for them to terminate
-                    System.exit(0);
+                    if (exitOnFailure) {
+                        System.exit(0);
+                    }
                 } catch (InterruptedException ex) {
                     Thread.interrupted();
                     ex.printStackTrace(System.err);

--- a/src/main/java/io/numaproj/numaflow/sourcetransformer/Service.java
+++ b/src/main/java/io/numaproj/numaflow/sourcetransformer/Service.java
@@ -5,6 +5,7 @@ import akka.actor.ActorSystem;
 import com.google.protobuf.Empty;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+import io.numaproj.numaflow.shared.InputStreamError;
 import io.numaproj.numaflow.sourcetransformer.v1.SourceTransformGrpc;
 import io.numaproj.numaflow.sourcetransformer.v1.Sourcetransformer;
 import lombok.AllArgsConstructor;
@@ -64,7 +65,7 @@ class Service extends SourceTransformGrpc.SourceTransformImplBase {
 
             @Override
             public void onError(Throwable throwable) {
-                transformSupervisorActor.tell(new Exception(throwable), ActorRef.noSender());
+                transformSupervisorActor.tell(new InputStreamError(throwable), ActorRef.noSender());
             }
 
             @Override

--- a/src/main/java/io/numaproj/numaflow/sourcetransformer/TransformSupervisorActor.java
+++ b/src/main/java/io/numaproj/numaflow/sourcetransformer/TransformSupervisorActor.java
@@ -8,18 +8,17 @@ import akka.actor.Props;
 import akka.actor.SupervisorStrategy;
 import akka.japi.pf.DeciderBuilder;
 import akka.japi.pf.ReceiveBuilder;
-import io.grpc.stub.StreamObserver;
 import io.grpc.Status;
-import com.google.protobuf.Any;
-import com.google.rpc.Code;
-import com.google.rpc.DebugInfo;
 import io.grpc.protobuf.StatusProto;
+import io.grpc.stub.StreamObserver;
 import io.numaproj.numaflow.shared.ExceptionUtils;
+import io.numaproj.numaflow.shared.InputStreamError;
 import io.numaproj.numaflow.sourcetransformer.v1.Sourcetransformer;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * TransformSupervisorActor actor is responsible for distributing the messages to actors and handling failure.
@@ -52,6 +51,8 @@ class TransformSupervisorActor extends AbstractActor {
     private final SourceTransformer transformer;
     private final StreamObserver<Sourcetransformer.SourceTransformResponse> responseObserver;
     private final CompletableFuture<Void> shutdownSignal;
+    private final AtomicBoolean streamClosed = new AtomicBoolean(false);
+    private boolean inputCompleted;
     private int activeTransformersCount;
     private Exception userException;
 
@@ -69,6 +70,7 @@ class TransformSupervisorActor extends AbstractActor {
         this.transformer = transformer;
         this.responseObserver = responseObserver;
         this.shutdownSignal = shutdownSignal;
+        this.inputCompleted = false;
         this.userException = null;
         this.activeTransformersCount = 0;
     }
@@ -105,7 +107,7 @@ class TransformSupervisorActor extends AbstractActor {
                 .getSystem()
                 .log()
                 .warning("supervisor pre restart was executed due to: {}", reason.getMessage());
-        responseObserver.onError(Status.INTERNAL
+        sendError(Status.INTERNAL
                 .withDescription(reason.getMessage())
                 .withCause(reason)
                 .asException());
@@ -132,9 +134,10 @@ class TransformSupervisorActor extends AbstractActor {
                 .create()
                 .match(Sourcetransformer.SourceTransformRequest.class, this::processRequest)
                 .match(Sourcetransformer.SourceTransformResponse.class, this::sendResponse)
+                .match(InputStreamError.class, this::handleInputStreamError)
                 .match(Exception.class, this::handleFailure)
                 .match(AllDeadLetters.class, this::handleDeadLetters)
-                .match(String.class, eof -> responseObserver.onCompleted())
+                .match(String.class, eof -> handleInputCompleted())
                 .build();
     }
 
@@ -149,12 +152,12 @@ class TransformSupervisorActor extends AbstractActor {
             userException = e;
             // only send the very first exception to the client
             // one exception should trigger a container restart
-
             // Build gRPC Status
             com.google.rpc.Status status = ExceptionUtils.buildStatusFromUserException(e);
-            responseObserver.onError(StatusProto.toStatusRuntimeException(status));
+            sendError(StatusProto.toStatusRuntimeException(status));
         }
         activeTransformersCount--;
+        finishIfDrained();
     }
 
     /**
@@ -163,8 +166,16 @@ class TransformSupervisorActor extends AbstractActor {
      * @param transformResponse The SourceTransformResponse to be sent.
      */
     private void sendResponse(Sourcetransformer.SourceTransformResponse transformResponse) {
-        responseObserver.onNext(transformResponse);
-        activeTransformersCount--;
+        try {
+            if (!streamClosed.get()) {
+                responseObserver.onNext(transformResponse);
+            }
+        } catch (RuntimeException e) {
+            handleResponseObserverFailure(e);
+        } finally {
+            activeTransformersCount--;
+            finishIfDrained();
+        }
     }
 
     /**
@@ -175,12 +186,6 @@ class TransformSupervisorActor extends AbstractActor {
     private void processRequest(Sourcetransformer.SourceTransformRequest transformRequest) {
         if (userException != null) {
             log.info("a previous transformer actor failed, not processing any more requests");
-            if (activeTransformersCount == 0) {
-                log.info("there is no more active transformer AKKA actors - stopping the system");
-                getContext().getSystem().stop(getSelf());
-                log.info("AKKA system stopped");
-                shutdownSignal.completeExceptionally(userException);
-            }
             return;
         }
         // Create a TransformerActor for each incoming request.
@@ -193,6 +198,13 @@ class TransformSupervisorActor extends AbstractActor {
         activeTransformersCount++;
     }
 
+    private void handleInputStreamError(InputStreamError error) {
+        log.error("inbound request stream error, stopping source-transform supervisor", error.getCause());
+        streamClosed.set(true);
+        getContext().getSystem().stop(getSelf());
+        shutdownSignal.completeExceptionally(error.getCause());
+    }
+
     /**
      * Handles any dead letters that occur during the processing of the SourceTransformRequest.
      *
@@ -200,9 +212,59 @@ class TransformSupervisorActor extends AbstractActor {
      */
     private void handleDeadLetters(AllDeadLetters deadLetter) {
         log.debug("got a dead letter, stopping the execution");
-        responseObserver.onError(Status.INTERNAL.withDescription("dead letters").asException());
+        sendError(Status.INTERNAL.withDescription("dead letters").asException());
         getContext().getSystem().stop(getSelf());
         shutdownSignal.completeExceptionally(new Throwable("dead letters"));
+    }
+
+    private void handleInputCompleted() {
+        inputCompleted = true;
+        finishIfDrained();
+    }
+
+    // EOF and failures can arrive while child actors are still processing.
+    // Only finish the stream once all started child actors have replied or failed.
+    private void finishIfDrained() {
+        if (activeTransformersCount != 0) {
+            return;
+        }
+        if (userException != null) {
+            getContext().getSystem().stop(getSelf());
+            shutdownSignal.completeExceptionally(userException);
+            return;
+        }
+        if (inputCompleted) {
+            completeResponse();
+        }
+    }
+
+    private void completeResponse() {
+        if (streamClosed.compareAndSet(false, true)) {
+            try {
+                responseObserver.onCompleted();
+            } catch (RuntimeException e) {
+                handleResponseObserverFailure(e);
+            } finally {
+                getContext().getSystem().stop(getSelf());
+            }
+        }
+    }
+
+    private void sendError(Throwable throwable) {
+        if (streamClosed.compareAndSet(false, true)) {
+            try {
+                responseObserver.onError(throwable);
+            } catch (RuntimeException e) {
+                handleResponseObserverFailure(e);
+            }
+        }
+    }
+
+    private void handleResponseObserverFailure(RuntimeException e) {
+        log.warn("response stream is already closed; stopping source-transform supervisor", e);
+        streamClosed.set(true);
+        getContext().getSystem().stop(getSelf());
+        shutdownSignal.completeExceptionally(e);
     }
 
     /**
@@ -216,10 +278,11 @@ class TransformSupervisorActor extends AbstractActor {
         return new AllForOneStrategy(
                 DeciderBuilder
                         .match(Exception.class, e -> {
-                            responseObserver.onError(Status.INTERNAL
+                            sendError(Status.INTERNAL
                                     .withDescription(e.getMessage())
                                     .withCause(e)
                                     .asException());
+                            shutdownSignal.completeExceptionally(e);
                             return SupervisorStrategy.stop();
                         })
                         .build());

--- a/src/test/java/io/numaproj/numaflow/mapper/MapSupervisorActorTest.java
+++ b/src/test/java/io/numaproj/numaflow/mapper/MapSupervisorActorTest.java
@@ -1,0 +1,209 @@
+package io.numaproj.numaflow.mapper;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import com.google.protobuf.ByteString;
+import io.grpc.stub.StreamObserver;
+import io.numaproj.numaflow.map.v1.MapOuterClass;
+import io.numaproj.numaflow.shared.InputStreamError;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class MapSupervisorActorTest {
+
+    @Test
+    public void given_inputStreamError_when_supervisorHandlesIt_then_shutdownCompletesWithoutResponseWrite() throws Exception {
+        ActorSystem actorSystem = ActorSystem.create("mapper-input-error-test");
+        CompletableFuture<Void> shutdownSignal = new CompletableFuture<>();
+        RecordingObserver responseObserver = new RecordingObserver();
+        RuntimeException streamError = new RuntimeException("client cancelled");
+
+        try {
+            ActorRef supervisor = actorSystem.actorOf(
+                    MapSupervisorActor.props(new BlockingMapper(new CountDownLatch(0), new CountDownLatch(0)),
+                            responseObserver,
+                            shutdownSignal));
+
+            supervisor.tell(new InputStreamError(streamError), ActorRef.noSender());
+
+            ExecutionException exception = assertCompletesExceptionally(shutdownSignal);
+            assertSame(streamError, exception.getCause());
+            assertTrue(responseObserver.events.isEmpty());
+        } finally {
+            actorSystem.terminate();
+        }
+    }
+
+    @Test
+    public void given_eofArrivesBeforeChildResponse_when_childDrains_then_responseIsSentBeforeCompleted() throws Exception {
+        ActorSystem actorSystem = ActorSystem.create("mapper-drain-test");
+        CompletableFuture<Void> shutdownSignal = new CompletableFuture<>();
+        CountDownLatch mapperStarted = new CountDownLatch(1);
+        CountDownLatch releaseMapper = new CountDownLatch(1);
+        RecordingObserver responseObserver = new RecordingObserver();
+
+        try {
+            ActorRef supervisor = actorSystem.actorOf(
+                    MapSupervisorActor.props(new BlockingMapper(mapperStarted, releaseMapper),
+                            responseObserver,
+                            shutdownSignal));
+
+            supervisor.tell(mapRequest(), ActorRef.noSender());
+            assertTrue(mapperStarted.await(2, TimeUnit.SECONDS));
+            supervisor.tell(Constants.EOF, ActorRef.noSender());
+
+            Thread.sleep(100);
+            assertFalse(responseObserver.completed.isDone());
+
+            releaseMapper.countDown();
+
+            assertTrue(responseObserver.completed.get(2, TimeUnit.SECONDS));
+            assertEquals(List.of("next", "completed"), responseObserver.events);
+        } finally {
+            actorSystem.terminate();
+        }
+    }
+
+    @Test
+    public void given_childFailure_when_childDrains_then_shutdownCompletesExceptionally() throws Exception {
+        ActorSystem actorSystem = ActorSystem.create("mapper-failure-test");
+        CompletableFuture<Void> shutdownSignal = new CompletableFuture<>();
+        RecordingObserver responseObserver = new RecordingObserver();
+
+        try {
+            ActorRef supervisor = actorSystem.actorOf(
+                    MapSupervisorActor.props(new FailingMapper(), responseObserver, shutdownSignal));
+
+            supervisor.tell(mapRequest(), ActorRef.noSender());
+
+            assertCompletesExceptionally(shutdownSignal);
+            assertTrue(responseObserver.error.get(2, TimeUnit.SECONDS) instanceof RuntimeException);
+        } finally {
+            actorSystem.terminate();
+        }
+    }
+
+    @Test
+    public void given_responseObserverThrowsOnNext_when_supervisorHandlesResponse_then_shutdownCompletesExceptionally()
+            throws Exception {
+        ActorSystem actorSystem = ActorSystem.create("mapper-closed-response-test");
+        CompletableFuture<Void> shutdownSignal = new CompletableFuture<>();
+
+        try {
+            ActorRef supervisor = actorSystem.actorOf(
+                    MapSupervisorActor.props(new BlockingMapper(new CountDownLatch(0), new CountDownLatch(0)),
+                            new FailingOnNextObserver(),
+                            shutdownSignal));
+
+            supervisor.tell(mapRequest(), ActorRef.noSender());
+
+            ExecutionException exception = assertCompletesExceptionally(shutdownSignal);
+            assertTrue(exception.getCause() instanceof IllegalStateException);
+            assertEquals("call already closed", exception.getCause().getMessage());
+        } finally {
+            actorSystem.terminate();
+        }
+    }
+
+    private static MapOuterClass.MapRequest mapRequest() {
+        return MapOuterClass.MapRequest.newBuilder()
+                .setId("id")
+                .setRequest(MapOuterClass.MapRequest.Request.newBuilder()
+                        .setValue(ByteString.copyFromUtf8("input"))
+                        .addKeys("key")
+                        .build())
+                .build();
+    }
+
+    private static ExecutionException assertCompletesExceptionally(CompletableFuture<Void> future)
+            throws InterruptedException {
+        try {
+            future.get(2, TimeUnit.SECONDS);
+        } catch (ExecutionException e) {
+            return e;
+        } catch (java.util.concurrent.TimeoutException e) {
+            throw new AssertionError("expected future to complete exceptionally", e);
+        }
+        throw new AssertionError("expected future to complete exceptionally");
+    }
+
+    private static class BlockingMapper extends Mapper {
+        private final CountDownLatch started;
+        private final CountDownLatch release;
+
+        private BlockingMapper(CountDownLatch started, CountDownLatch release) {
+            this.started = started;
+            this.release = release;
+        }
+
+        @Override
+        public MessageList processMessage(String[] keys, Datum datum) {
+            started.countDown();
+            try {
+                release.await(2, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+            return MessageList.newBuilder()
+                    .addMessage(new Message("output".getBytes()))
+                    .build();
+        }
+    }
+
+    private static class FailingMapper extends Mapper {
+        @Override
+        public MessageList processMessage(String[] keys, Datum datum) {
+            throw new RuntimeException("user failure");
+        }
+    }
+
+    private static class RecordingObserver implements StreamObserver<MapOuterClass.MapResponse> {
+        private final List<String> events = new CopyOnWriteArrayList<>();
+        private final CompletableFuture<Boolean> completed = new CompletableFuture<>();
+        private final CompletableFuture<Throwable> error = new CompletableFuture<>();
+
+        @Override
+        public void onNext(MapOuterClass.MapResponse mapResponse) {
+            events.add("next");
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            events.add("error");
+            error.complete(throwable);
+        }
+
+        @Override
+        public void onCompleted() {
+            events.add("completed");
+            completed.complete(true);
+        }
+    }
+
+    private static class FailingOnNextObserver implements StreamObserver<MapOuterClass.MapResponse> {
+        @Override
+        public void onNext(MapOuterClass.MapResponse mapResponse) {
+            throw new IllegalStateException("call already closed");
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+        }
+
+        @Override
+        public void onCompleted() {
+        }
+    }
+}

--- a/src/test/java/io/numaproj/numaflow/mapstreamer/MapStreamSupervisorActorTest.java
+++ b/src/test/java/io/numaproj/numaflow/mapstreamer/MapStreamSupervisorActorTest.java
@@ -1,0 +1,207 @@
+package io.numaproj.numaflow.mapstreamer;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import com.google.protobuf.ByteString;
+import io.grpc.stub.StreamObserver;
+import io.numaproj.numaflow.map.v1.MapOuterClass;
+import io.numaproj.numaflow.shared.InputStreamError;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class MapStreamSupervisorActorTest {
+
+    @Test
+    public void given_inputStreamError_when_supervisorHandlesIt_then_shutdownCompletesWithoutResponseWrite() throws Exception {
+        ActorSystem actorSystem = ActorSystem.create("mapstream-input-error-test");
+        CompletableFuture<Void> shutdownSignal = new CompletableFuture<>();
+        RecordingObserver responseObserver = new RecordingObserver();
+        RuntimeException streamError = new RuntimeException("client cancelled");
+
+        try {
+            ActorRef supervisor = actorSystem.actorOf(
+                    MapStreamSupervisorActor.props(new BlockingMapStreamer(new CountDownLatch(0), new CountDownLatch(0)),
+                            responseObserver,
+                            shutdownSignal));
+
+            supervisor.tell(new InputStreamError(streamError), ActorRef.noSender());
+
+            ExecutionException exception = assertCompletesExceptionally(shutdownSignal);
+            assertSame(streamError, exception.getCause());
+            assertTrue(responseObserver.events.isEmpty());
+        } finally {
+            actorSystem.terminate();
+        }
+    }
+
+    @Test
+    public void given_eofArrivesBeforeChildResponses_when_childDrains_then_responsesAreSentBeforeCompleted() throws Exception {
+        ActorSystem actorSystem = ActorSystem.create("mapstream-drain-test");
+        CompletableFuture<Void> shutdownSignal = new CompletableFuture<>();
+        CountDownLatch streamerStarted = new CountDownLatch(1);
+        CountDownLatch releaseStreamer = new CountDownLatch(1);
+        RecordingObserver responseObserver = new RecordingObserver();
+
+        try {
+            ActorRef supervisor = actorSystem.actorOf(
+                    MapStreamSupervisorActor.props(new BlockingMapStreamer(streamerStarted, releaseStreamer),
+                            responseObserver,
+                            shutdownSignal));
+
+            supervisor.tell(mapRequest(), ActorRef.noSender());
+            assertTrue(streamerStarted.await(2, TimeUnit.SECONDS));
+            supervisor.tell(Constants.EOF, ActorRef.noSender());
+
+            Thread.sleep(100);
+            assertFalse(responseObserver.completed.isDone());
+
+            releaseStreamer.countDown();
+
+            assertTrue(responseObserver.completed.get(2, TimeUnit.SECONDS));
+            assertEquals(List.of("next", "next", "completed"), responseObserver.events);
+        } finally {
+            actorSystem.terminate();
+        }
+    }
+
+    @Test
+    public void given_childFailure_when_childDrains_then_shutdownCompletesExceptionally() throws Exception {
+        ActorSystem actorSystem = ActorSystem.create("mapstream-failure-test");
+        CompletableFuture<Void> shutdownSignal = new CompletableFuture<>();
+        RecordingObserver responseObserver = new RecordingObserver();
+
+        try {
+            ActorRef supervisor = actorSystem.actorOf(
+                    MapStreamSupervisorActor.props(new FailingMapStreamer(), responseObserver, shutdownSignal));
+
+            supervisor.tell(mapRequest(), ActorRef.noSender());
+
+            assertCompletesExceptionally(shutdownSignal);
+            assertTrue(responseObserver.error.get(2, TimeUnit.SECONDS) instanceof RuntimeException);
+        } finally {
+            actorSystem.terminate();
+        }
+    }
+
+    @Test
+    public void given_responseObserverThrowsOnNext_when_supervisorHandlesResponse_then_shutdownCompletesExceptionally()
+            throws Exception {
+        ActorSystem actorSystem = ActorSystem.create("mapstream-closed-response-test");
+        CompletableFuture<Void> shutdownSignal = new CompletableFuture<>();
+
+        try {
+            ActorRef supervisor = actorSystem.actorOf(
+                    MapStreamSupervisorActor.props(new BlockingMapStreamer(new CountDownLatch(0), new CountDownLatch(0)),
+                            new FailingOnNextObserver(),
+                            shutdownSignal));
+
+            supervisor.tell(mapRequest(), ActorRef.noSender());
+
+            ExecutionException exception = assertCompletesExceptionally(shutdownSignal);
+            assertTrue(exception.getCause() instanceof IllegalStateException);
+            assertEquals("call already closed", exception.getCause().getMessage());
+        } finally {
+            actorSystem.terminate();
+        }
+    }
+
+    private static MapOuterClass.MapRequest mapRequest() {
+        return MapOuterClass.MapRequest.newBuilder()
+                .setId("id")
+                .setRequest(MapOuterClass.MapRequest.Request.newBuilder()
+                        .setValue(ByteString.copyFromUtf8("input"))
+                        .addKeys("key")
+                        .build())
+                .build();
+    }
+
+    private static ExecutionException assertCompletesExceptionally(CompletableFuture<Void> future)
+            throws InterruptedException {
+        try {
+            future.get(2, TimeUnit.SECONDS);
+        } catch (ExecutionException e) {
+            return e;
+        } catch (java.util.concurrent.TimeoutException e) {
+            throw new AssertionError("expected future to complete exceptionally", e);
+        }
+        throw new AssertionError("expected future to complete exceptionally");
+    }
+
+    private static class BlockingMapStreamer extends MapStreamer {
+        private final CountDownLatch started;
+        private final CountDownLatch release;
+
+        private BlockingMapStreamer(CountDownLatch started, CountDownLatch release) {
+            this.started = started;
+            this.release = release;
+        }
+
+        @Override
+        public void processMessage(String[] keys, Datum datum, OutputObserver outputObserver) {
+            started.countDown();
+            try {
+                release.await(2, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+            outputObserver.send(new Message("output".getBytes()));
+        }
+    }
+
+    private static class FailingMapStreamer extends MapStreamer {
+        @Override
+        public void processMessage(String[] keys, Datum datum, OutputObserver outputObserver) {
+            throw new RuntimeException("user failure");
+        }
+    }
+
+    private static class RecordingObserver implements StreamObserver<MapOuterClass.MapResponse> {
+        private final List<String> events = new CopyOnWriteArrayList<>();
+        private final CompletableFuture<Boolean> completed = new CompletableFuture<>();
+        private final CompletableFuture<Throwable> error = new CompletableFuture<>();
+
+        @Override
+        public void onNext(MapOuterClass.MapResponse mapResponse) {
+            events.add("next");
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            events.add("error");
+            error.complete(throwable);
+        }
+
+        @Override
+        public void onCompleted() {
+            events.add("completed");
+            completed.complete(true);
+        }
+    }
+
+    private static class FailingOnNextObserver implements StreamObserver<MapOuterClass.MapResponse> {
+        @Override
+        public void onNext(MapOuterClass.MapResponse mapResponse) {
+            throw new IllegalStateException("call already closed");
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+        }
+
+        @Override
+        public void onCompleted() {
+        }
+    }
+}

--- a/src/test/java/io/numaproj/numaflow/sourcetransformer/TransformSupervisorActorTest.java
+++ b/src/test/java/io/numaproj/numaflow/sourcetransformer/TransformSupervisorActorTest.java
@@ -1,0 +1,210 @@
+package io.numaproj.numaflow.sourcetransformer;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import com.google.protobuf.ByteString;
+import io.grpc.stub.StreamObserver;
+import io.numaproj.numaflow.shared.InputStreamError;
+import io.numaproj.numaflow.sourcetransformer.v1.Sourcetransformer;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class TransformSupervisorActorTest {
+
+    @Test
+    public void given_inputStreamError_when_supervisorHandlesIt_then_shutdownCompletesWithoutResponseWrite() throws Exception {
+        ActorSystem actorSystem = ActorSystem.create("transform-input-error-test");
+        CompletableFuture<Void> shutdownSignal = new CompletableFuture<>();
+        RecordingObserver responseObserver = new RecordingObserver();
+        RuntimeException streamError = new RuntimeException("client cancelled");
+
+        try {
+            ActorRef supervisor = actorSystem.actorOf(
+                    TransformSupervisorActor.props(new BlockingTransformer(new CountDownLatch(0), new CountDownLatch(0)),
+                            responseObserver,
+                            shutdownSignal));
+
+            supervisor.tell(new InputStreamError(streamError), ActorRef.noSender());
+
+            ExecutionException exception = assertCompletesExceptionally(shutdownSignal);
+            assertSame(streamError, exception.getCause());
+            assertTrue(responseObserver.events.isEmpty());
+        } finally {
+            actorSystem.terminate();
+        }
+    }
+
+    @Test
+    public void given_eofArrivesBeforeChildResponse_when_childDrains_then_responseIsSentBeforeCompleted() throws Exception {
+        ActorSystem actorSystem = ActorSystem.create("transform-drain-test");
+        CompletableFuture<Void> shutdownSignal = new CompletableFuture<>();
+        CountDownLatch transformerStarted = new CountDownLatch(1);
+        CountDownLatch releaseTransformer = new CountDownLatch(1);
+        RecordingObserver responseObserver = new RecordingObserver();
+
+        try {
+            ActorRef supervisor = actorSystem.actorOf(
+                    TransformSupervisorActor.props(new BlockingTransformer(transformerStarted, releaseTransformer),
+                            responseObserver,
+                            shutdownSignal));
+
+            supervisor.tell(transformRequest(), ActorRef.noSender());
+            assertTrue(transformerStarted.await(2, TimeUnit.SECONDS));
+            supervisor.tell(Constants.EOF, ActorRef.noSender());
+
+            Thread.sleep(100);
+            assertFalse(responseObserver.completed.isDone());
+
+            releaseTransformer.countDown();
+
+            assertTrue(responseObserver.completed.get(2, TimeUnit.SECONDS));
+            assertEquals(List.of("next", "completed"), responseObserver.events);
+        } finally {
+            actorSystem.terminate();
+        }
+    }
+
+    @Test
+    public void given_childFailure_when_childDrains_then_shutdownCompletesExceptionally() throws Exception {
+        ActorSystem actorSystem = ActorSystem.create("transform-failure-test");
+        CompletableFuture<Void> shutdownSignal = new CompletableFuture<>();
+        RecordingObserver responseObserver = new RecordingObserver();
+
+        try {
+            ActorRef supervisor = actorSystem.actorOf(
+                    TransformSupervisorActor.props(new FailingTransformer(), responseObserver, shutdownSignal));
+
+            supervisor.tell(transformRequest(), ActorRef.noSender());
+
+            assertCompletesExceptionally(shutdownSignal);
+            assertTrue(responseObserver.error.get(2, TimeUnit.SECONDS) instanceof RuntimeException);
+        } finally {
+            actorSystem.terminate();
+        }
+    }
+
+    @Test
+    public void given_responseObserverThrowsOnNext_when_supervisorHandlesResponse_then_shutdownCompletesExceptionally()
+            throws Exception {
+        ActorSystem actorSystem = ActorSystem.create("transform-closed-response-test");
+        CompletableFuture<Void> shutdownSignal = new CompletableFuture<>();
+
+        try {
+            ActorRef supervisor = actorSystem.actorOf(
+                    TransformSupervisorActor.props(new BlockingTransformer(new CountDownLatch(0), new CountDownLatch(0)),
+                            new FailingOnNextObserver(),
+                            shutdownSignal));
+
+            supervisor.tell(transformRequest(), ActorRef.noSender());
+
+            ExecutionException exception = assertCompletesExceptionally(shutdownSignal);
+            assertTrue(exception.getCause() instanceof IllegalStateException);
+            assertEquals("call already closed", exception.getCause().getMessage());
+        } finally {
+            actorSystem.terminate();
+        }
+    }
+
+    private static Sourcetransformer.SourceTransformRequest transformRequest() {
+        return Sourcetransformer.SourceTransformRequest.newBuilder()
+                .setRequest(Sourcetransformer.SourceTransformRequest.Request.newBuilder()
+                        .setValue(ByteString.copyFromUtf8("input"))
+                        .addKeys("key")
+                        .setId("id")
+                        .build())
+                .build();
+    }
+
+    private static ExecutionException assertCompletesExceptionally(CompletableFuture<Void> future)
+            throws InterruptedException {
+        try {
+            future.get(2, TimeUnit.SECONDS);
+        } catch (ExecutionException e) {
+            return e;
+        } catch (java.util.concurrent.TimeoutException e) {
+            throw new AssertionError("expected future to complete exceptionally", e);
+        }
+        throw new AssertionError("expected future to complete exceptionally");
+    }
+
+    private static class BlockingTransformer extends SourceTransformer {
+        private final CountDownLatch started;
+        private final CountDownLatch release;
+
+        private BlockingTransformer(CountDownLatch started, CountDownLatch release) {
+            this.started = started;
+            this.release = release;
+        }
+
+        @Override
+        public MessageList processMessage(String[] keys, Datum datum) {
+            started.countDown();
+            try {
+                release.await(2, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+            return MessageList.newBuilder()
+                    .addMessage(new Message("output".getBytes(), Instant.EPOCH))
+                    .build();
+        }
+    }
+
+    private static class FailingTransformer extends SourceTransformer {
+        @Override
+        public MessageList processMessage(String[] keys, Datum datum) {
+            throw new RuntimeException("user failure");
+        }
+    }
+
+    private static class RecordingObserver implements StreamObserver<Sourcetransformer.SourceTransformResponse> {
+        private final List<String> events = new CopyOnWriteArrayList<>();
+        private final CompletableFuture<Boolean> completed = new CompletableFuture<>();
+        private final CompletableFuture<Throwable> error = new CompletableFuture<>();
+
+        @Override
+        public void onNext(Sourcetransformer.SourceTransformResponse sourceTransformResponse) {
+            events.add("next");
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            events.add("error");
+            error.complete(throwable);
+        }
+
+        @Override
+        public void onCompleted() {
+            events.add("completed");
+            completed.complete(true);
+        }
+    }
+
+    private static class FailingOnNextObserver implements StreamObserver<Sourcetransformer.SourceTransformResponse> {
+        @Override
+        public void onNext(Sourcetransformer.SourceTransformResponse sourceTransformResponse) {
+            throw new IllegalStateException("call already closed");
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+        }
+
+        @Override
+        public void onCompleted() {
+        }
+    }
+}


### PR DESCRIPTION
### Summary

- This PR fixes a stuck UDF container issue caused by writes to a gRPC response stream after the client/runtime had already cancelled or closed the call.
- The affected supervisors now guard all response stream writes, distinguish inbound gRPC stream errors from child actor failures, and finish streams only after all in-flight child actors have drained.

### What Changed
- Added guarded response handling in mapper, map-streamer, and source-transformer supervisors.

    -  `onNext`, `onError`, and `onCompleted` are now protected so closed/cancelled gRPC calls do not throw back into Akka supervision.
   - This prevents `call already closed` from triggering supervisor restart/preRestart loops.

- Added a shared `InputStreamError` actor message.
  - `Service.onError()` now sends `InputStreamError` instead of wrapping the throwable as an `Exception`.
  - This keeps inbound request-stream failures separate from child actor UDF failures.
  - As a result, supervisors no longer decrement active child counts for client cancellation/network errors.


- Added drain-based completion through `inputCompleted` and `finishIfDrained()`.
  - EOF no longer immediately calls `responseObserver.onCompleted()`.
  - The supervisor waits until all started child actors have replied or failed.
  - If a UDF error occurred, the shutdown signal is completed once active work drains.
  - Otherwise, normal completion is sent after active work drains.

- Updated map-streamer EOF handling.
  - `Service.onCompleted()` now routes EOF through the supervisor instead of completing the response stream directly.
  - This aligns map-streamer behaviour with mapper and source-transformer.
- [**Tests**] Preserved production shutdown behaviour while making tests safe.
  - Mapper/source-transformer production servers still call `System.exit(0)` on failure.
  - Test constructors disable JVM exit so expected failure-path tests do not put the Maven test JVM into shutdown.

### Why

- Previously, EOF or client cancellation could close the response stream while child actors were still processing. Later child responses could then attempt `onNext()` on a closed gRPC call, producing errors like `call already closed`.

- Also, user exceptions did not always complete `shutdownSignal`; shutdown could depend on a later request arriving. If no later request arrived, the UDF container could remain stuck.

### Issue observed in live Pipeline

udf container was stuck after this error

`Caused by: java.lang.IllegalStateException: call already closedat java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)at akka.dispatch.Mailbox.exec(Mailbox.scala:243)at akka.dispatch.Mailbox.run(Mailbox.scala:230)at akka.dispatch.Mailbox.processAllSystemMessages(Mailbox.scala:295)at akka.actor.ActorCell.systemInvoke(ActorCell.scala:535)at akka.actor.ActorCell.invokeAll$1(ActorCell.scala:516)at akka.actor.ActorCell.faultRecreate(ActorCell.scala:410)at akka.actor.dungeon.FaultHandling.faultRecreate$(FaultHandling.scala:36)at akka.actor.dungeon.FaultHandling.faultRecreate(FaultHandling.scala:98)at scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:35)at akka.actor.dungeon.FaultHandling$$anon$1.applyOrElse(FaultHandling.scala:336)at akka.actor.dungeon.FaultHandling$$anon$1.applyOrElse(FaultHandling.scala:341)at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)at akka.actor.dungeon.FaultHandling.$anonfun$1(FaultHandling.scala:96)at akka.actor.PreRestartException$.apply(Actor.scala:214)akka.actor.PreRestartException: akka://mapper/user/$c: exception in preRestart(class io.grpc.StatusRuntimeException, class io.numaproj.numaflow.map.v1.MapOuterClass$MapResponse)[ERROR] [04/27/2026 10:17:25.177] [mapper-akka.actor.default-dispatcher-372] [akka://mapper/user/$c] call already closed[WARN] [04/27/2026 10:17:25.176] [mapper-akka.actor.default-dispatcher-372] [akka.actor.ActorSystemImpl(mapper)] supervisor pre restart was executed due to: CANCELLED: call already cancelled. Use ServerCallStreamObserver.setOnCancelHandler() to disable this exception[INFO] [akkaDeadLetter][04/27/2026 10:17:25.176] [mapper-akka.actor.default-dispatcher-377] [akka://mapper/user/$c/$e] Message [akka.dispatch.sysmsg.Suspend] from Actor[akka://mapper/user/$c/$e#-865804973] to Actor[akka://mapper/user/$c/$e#-865804973] was not delivered. [7] dead letters encountered. If this is not an expected behavior then Actor[akka://mapper/user/$c/$e#-865804973] may have terminated unexpectedly. This logging can be turned off or adjusted with configuration settings 'akka.log-dead-letters' and 'akka.log-dead-letters-during-shutdown'.at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)at akka.dispatch.Mailbox.exec(Mailbox.scala:243)at akka.dispatch.Mailbox.run(Mailbox.scala:231)at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:270)at akka.actor.ActorCell.invoke(ActorCell.scala:547)at akka.actor.ActorCell.receiveMessage(ActorCell.scala:579)at akka.actor.AbstractActor.aroundReceive(AbstractActor.scala:219)at akka.actor.Actor.aroundReceive$(Actor.scala:471)at akka.actor.Actor.aroundReceive(Actor.scala:537)at scala.PartialFunction$OrElse.applyOrElse(PartialFunction.scala:270)at scala.PartialFunction$OrElse.applyOrElse(PartialFunction.scala:269)at akka.japi.pf.UnitCaseStatement.applyOrElse(CaseStatements.scala:20)at scala.PartialFunction.applyOrElse$(PartialFunction.scala:213)at scala.PartialFunction.applyOrElse(PartialFunction.scala:214)at akka.japi.pf.UnitCaseStatement.apply(CaseStatements.scala:24)at akka.japi.pf.UnitCaseStatement.apply(CaseStatements.scala:24)at io.numaproj.numaflow.mapper.MapSupervisorActor.sendResponse(MapSupervisorActor.java:118)at io.grpc.stub.ServerCalls$ServerCallStreamObserverImpl.onNext(ServerCalls.java:366)at io.grpc.Status.asRuntimeException(Status.java:525)io.grpc.StatusRuntimeException: CANCELLED: call already cancelled. Use ServerCallStreamObserver.setOnCancelHandler() to disable this exception[ERROR] [04/27/2026 10:17:25.176] [mapper-akka.actor.internal-dispatcher-380] [akka://mapper/user/$c] CANCELLED: call already cancelled. Use ServerCallStreamObserver.setOnCancelHandler() to disable this exception... 12 moreat akka.actor.dungeon.FaultHandling.faultRecreate(FaultHandling.scala:94)`